### PR TITLE
Rename CAN fmp0 register to fmp, remove references to FIFO 0 in CAN registers

### DIFF
--- a/data/registers/can_l1.yaml
+++ b/data/registers/can_l1.yaml
@@ -15,7 +15,7 @@ block/CAN:
       byte_offset: 8
       fieldset: TSTATR
     - name: RFIFO
-      description: CAN receive FIFO 0 register.
+      description: CAN receive FIFO register.
       byte_offset: 12
       fieldset: RFIFO
       array:
@@ -400,22 +400,22 @@ fieldset/INTENR:
       bit_offset: 17
       bit_size: 1
 fieldset/RFIFO:
-  description: CAN receive FIFO 0/1 register.
+  description: CAN receive FIFO register.
   fields:
-    - name: FMP0
-      description: FIFO 0 message pending.
+    - name: FMP
+      description: FIFO message pending.
       bit_offset: 0
       bit_size: 2
     - name: FULL
-      description: FIFO 0 full.
+      description: FIFO full.
       bit_offset: 3
       bit_size: 1
     - name: FOVR
-      description: FIFO 0 overrun.
+      description: FIFO overrun.
       bit_offset: 4
       bit_size: 1
     - name: RFOM
-      description: Release FIFO 0 output mailbox.
+      description: Release FIFO output mailbox.
       bit_offset: 5
       bit_size: 1
 fieldset/RXMDHR:

--- a/data/registers/can_v1.yaml
+++ b/data/registers/can_v1.yaml
@@ -15,7 +15,7 @@ block/CAN:
       byte_offset: 8
       fieldset: TSTATR
     - name: RFIFO
-      description: CAN receive FIFO 0 register.
+      description: CAN receive FIFO register.
       byte_offset: 12
       fieldset: RFIFO
       array:
@@ -340,22 +340,22 @@ fieldset/INTENR:
       bit_offset: 17
       bit_size: 1
 fieldset/RFIFO:
-  description: CAN receive FIFO 0/1 register.
+  description: CAN receive FIFO register.
   fields:
-    - name: FMP0
-      description: FIFO 0 message pending.
+    - name: FMP
+      description: FIFO message pending.
       bit_offset: 0
       bit_size: 2
     - name: FULL
-      description: FIFO 0 full.
+      description: FIFO full.
       bit_offset: 3
       bit_size: 1
     - name: FOVR
-      description: FIFO 0 overrun.
+      description: FIFO overrun.
       bit_offset: 4
       bit_size: 1
     - name: RFOM
-      description: Release FIFO 0 output mailbox.
+      description: Release FIFO output mailbox.
       bit_offset: 5
       bit_size: 1
 fieldset/RXMDHR:

--- a/data/registers/can_v3.yaml
+++ b/data/registers/can_v3.yaml
@@ -15,7 +15,7 @@ block/CAN:
       byte_offset: 8
       fieldset: TSTATR
     - name: RFIFO
-      description: CAN receive FIFO 0 register.
+      description: CAN receive FIFO register.
       byte_offset: 12
       fieldset: RFIFO
       array:
@@ -348,22 +348,22 @@ fieldset/INTENR:
       bit_offset: 17
       bit_size: 1
 fieldset/RFIFO:
-  description: CAN receive FIFO 0/1 register.
+  description: CAN receive FIFO register.
   fields:
-    - name: FMP0
-      description: FIFO 0 message pending.
+    - name: FMP
+      description: FIFO message pending.
       bit_offset: 0
       bit_size: 2
     - name: FULL
-      description: FIFO 0 full.
+      description: FIFO full.
       bit_offset: 3
       bit_size: 1
     - name: FOVR
-      description: FIFO 0 overrun.
+      description: FIFO overrun.
       bit_offset: 4
       bit_size: 1
     - name: RFOM
-      description: Release FIFO 0 output mailbox.
+      description: Release FIFO output mailbox.
       bit_offset: 5
       bit_size: 1
 fieldset/RXMDHR:


### PR DESCRIPTION
Since the refactor in 4a1b64f095c0c24609661c08c04a75d7081ddbb6, all CAN fifo registers now use offsets instead of explicit fifo0/fifo1 access. I've updated some of the registers to better reflect this change.