### PR TITLE
Split ch641 from v0

### DIFF
--- a/data/family/CH641.yaml
+++ b/data/family/CH641.yaml
@@ -34,6 +34,13 @@
     - signal: EXTI8
       interrupt: EXTI15_8
 
+- name: EXTEND
+  address: 0x40023800
+  registers:
+    kind: extend
+    version: ch641
+    block: EXTEND
+
 - name: RCC
   address: 0x40021000
   registers:
@@ -310,7 +317,7 @@
   address: 0x40012400
   registers:
     kind: adc
-    version: v0
+    version: ch641
     block: ADC
   rcc:
     bus_clock: PCLK2
@@ -341,7 +348,7 @@
       signal: IN6
     - pin: PB7
       signal: IN7
-    # TODO: ISP pin, IN8
+    # ISP pin is binded to IN8
     - pin: PB8
       signal: IN9
     - pin: PB0
@@ -361,3 +368,27 @@
       signal: ETR
       remap: 0
 
+- name: USBPD
+  address: 0x40027000
+  registers:
+    kind: usbpd
+    version: ch641
+    block: USBPD
+  rcc:
+    bus_clock: HCLK
+    kernel_clock: HCLK
+    enable:
+      register: AHBPCENR
+      field: USBPDEN
+    reset:
+      register: AHBRSTR
+      field: USBPDRST
+  interrupts:
+    - signal: GLOBAL
+      interrupt: USBPD
+    - signal: WKUP
+      interrupt: USBPD_WKUP
+  pins:
+    - { pin: "PB0", signal: "CC1" }
+    - { pin: "PB1", signal: "CC2" } # No Rd
+    - { pin: "PB9", signal: "CC3" }

--- a/data/family/CH641.yaml
+++ b/data/family/CH641.yaml
@@ -380,9 +380,6 @@
     enable:
       register: AHBPCENR
       field: USBPDEN
-    reset:
-      register: AHBRSTR
-      field: USBPDRST
   interrupts:
     - signal: GLOBAL
       interrupt: USBPD

--- a/data/registers/adc_ch641.yaml
+++ b/data/registers/adc_ch641.yaml
@@ -1,5 +1,5 @@
 block/ADC:
-  description: Analog to digital converter for V003. No TKEY, 10bit.
+  description: Analog to digital converter for CH641. No TKEY, 10bit.
   items:
     - name: STATR
       description: status register.
@@ -326,28 +326,16 @@ enum/SAMPLE_TIME:
   variants:
     - name: Cycles3
       description: 3 cycles
-      value: 0
-    - name: Cycles9
-      description: 9 cycles
-      value: 1
-    - name: Cycles15
-      description: 15 cycles
-      value: 2
-    - name: Cycles30
-      description: 30 cycles
-      value: 3
-    - name: Cycles43
-      description: 43 cycles
-      value: 4
-    - name: Cycles57
-      description: 57 cycles
-      value: 5
-    - name: Cycles73
-      description: 73 cycles
-      value: 6
-    - name: Cycles241
-      description: 241 cycles
-      value: 7
+      value: 0b000
+    - name: Cycles13
+      description: 13 cycles
+      value: 0b001
+    - name: Cycles37
+      description: 37 cycles
+      value: 0b010
+    - name: Cycles49
+      description: 49 cycles
+      value: 0b011
 enum/EXTSEL:
   bit_size: 3
   description: External event select for regular group.
@@ -361,8 +349,8 @@ enum/EXTSEL:
     - name: TIM1_CC2
       description: Timer 1 capture compare 2.
       value: 0b010
-    - name: TIM2_TRGO
-      description: Timer 2 TRGO event.
+    - name: TIM1_CC3
+      description: Timer 1 capture compare 3.
       value: 0b011
     - name: TIM2_CC1
       description: Timer 2 capture compare 1.
@@ -370,8 +358,8 @@ enum/EXTSEL:
     - name: TIM2_CC2
       description: Timer 2 capture compare 2.
       value: 0b101
-    - name: PD3_PC2
-      description: PD3/PC2 pin.
+    - name: PA4_PA15
+      description: PA4/PA15 pin.
       value: 0b110
     - name: SWSTART
       description: Software start.
@@ -380,20 +368,23 @@ enum/JEXTSEL:
   bit_size: 3
   description: External event select for injected group.
   variants:
+    - name: TIM1_CC1
+      description: Timer 1 capture compare 1,
+      value: 0b001
+    - name: TIM1_CC2
+      description: Timer 1 capture compare 2.
+      value: 0b010
     - name: TIM1_CC3
       description: Timer 1 capture compare 3.
-      value: 0b000
-    - name: TIM1_CC4
-      description: Timer 1 capture compare 4.
-      value: 0b001
-    - name: TIM2_CC3
-      description: Timer 2 capture compare 3.
-      value: 0b010
-    - name: TIM2_CC4
-      description: Timer 2 capture compare 4.
       value: 0b011
-    - name: PD1_PA2
-      description: PD1/PA2 pin.
+    - name: TIM2_CC1
+      description: Timer 2 capture compare 1.
+      value: 0b100
+    - name: TIM2_CC2
+      description: Timer 2 capture compare 2.
+      value: 0b101
+    - name: PA4_PA15
+      description: PA4/PA15 pin.
       value: 0b110
     - name: JSWSTART
       description: Software start.

--- a/data/registers/extend_ch641.yaml
+++ b/data/registers/extend_ch641.yaml
@@ -1,0 +1,144 @@
+block/EXTEND:
+  description: Extend configuration.
+  items:
+    - name: CTLR0
+      description: Configure the extended control register 0.
+      byte_offset: 0
+      fieldset: CTLR0
+    - name: CTLR1
+      description: Configure the extended control register 1.
+      byte_offset: 8
+      fieldset: CTLR1
+    - name: CTLR2
+      description: Configure the extended control register 2.
+      byte_offset: 12
+      fieldset: CTLR2
+fieldset/CTLR0:
+  description: Configure the extended control register 0.
+  fields:
+    - name: LKUPEN
+      description: LOCKUP_Enable.
+      bit_offset: 6
+      bit_size: 1
+    - name: LKUPRST
+      description: LOCKUP RESET.
+      bit_offset: 7
+      bit_size: 1
+fieldset/CTLR1:
+  description: Configure the extended control register 1.
+  fields:
+    - name: UDP_BUFOE
+      description: UDP pin DAC_BUF output enable.
+      bit_offset: 0
+      bit_size: 1
+    - name: UDP_PCS
+      description: Select pull-up current or pull-down current.  built into the UDP pin.
+      bit_offset: 1
+      bit_size: 2
+    - name: UDP_PUE
+      description: UPD port DAC and programmable pull-down.  and pull-up mode selection.
+      bit_offset: 3
+      bit_size: 1
+    - name: UDP_PDE
+      description: UPD port DAC and programmable pull-down.  and pull-up mode selection.
+      bit_offset: 4
+      bit_size: 1
+    - name: UDP_DAC
+      description: UPD port DAC data/programmable pull-down.  resistor and pull-up resistor data.
+      bit_offset: 5
+      bit_size: 6
+    - name: UDP_AE
+      description: Enable of the UDP pin buffer/comparator DAC_BUF.
+      bit_offset: 11
+      bit_size: 1
+    - name: UDP_AI
+      description: Output of the UDP pin comparator DAC_BUF.
+      bit_offset: 12
+      bit_size: 1
+    - name: UDM_BUFOE
+      description: UDM pin DAC_BUF output enable.
+      bit_offset: 16
+      bit_size: 1
+    - name: UDM_PCS
+      description: Select pull-up current or pull-down current.  built into the UDM pin.
+      bit_offset: 17
+      bit_size: 2
+    - name: UDM_PUE
+      description: UPM port DAC and programmable pull-down.  and pull-up mode selection.
+      bit_offset: 19
+      bit_size: 1
+    - name: UDM_PDE
+      description: UPM port DAC and programmable pull-down.  and pull-up mode selection.
+      bit_offset: 20
+      bit_size: 1
+    - name: UDM_DAC
+      description: UPM port DAC data/programmable pull-down.  resistor and pull-up resistor data.
+      bit_offset: 21
+      bit_size: 6
+    - name: UDM_AE
+      description: Enable of the UDM pin buffer/comparator DAC_BUF.
+      bit_offset: 27
+      bit_size: 1
+    - name: UDM_AI
+      description: Output of the UDM pin comparator DAC_BUF.
+      bit_offset: 28
+      bit_size: 1
+fieldset/CTLR2:
+  description: Configure the extended control register 2.
+  fields:
+    - name: QII_AE
+      description: QII_OP and QII_CMP enable.
+      bit_offset: 0
+      bit_size: 1
+    - name: QII_PS
+      description: QII_OP channel selection at the input.
+      bit_offset: 1
+      bit_size: 1
+    - name: QII_AV
+      description: QII_OP gain select.
+      bit_offset: 2
+      bit_size: 1
+    - name: QII_HYP
+      description: QII_CMP hysteresis voltage selection.
+      bit_offset: 3
+      bit_size: 1
+    - name: QII_FILT
+      description: QII digital filtering enable.
+      bit_offset: 5
+      bit_size: 1
+    - name: ISP_AE
+      description: ISP_OP enable.
+      bit_offset: 8
+      bit_size: 1
+    - name: ISP_PS
+      description: ISP_OP channel selection at the positive input.
+      bit_offset: 9
+      bit_size: 1
+    - name: ISP_BE
+      description: ISP_OP bias enable.
+      bit_offset: 10
+      bit_size: 1
+    - name: ISP_NS
+      description: ISP_OP channel selection at the negative input.
+      bit_offset: 12
+      bit_size: 1
+    - name: CC1_REF
+      description: CC1 pin emulation reference enable.
+      bit_offset: 16
+      bit_size: 1
+    - name: CC2_REF
+      description: CC2 pin emulation reference enable.
+      bit_offset: 17
+      bit_size: 1
+    - name: CC3_REF
+      description: CC3 pin emulation reference enable.
+      bit_offset: 18
+      bit_size: 1
+    - name: CC_HVT
+      description: CC pin high threshold input mode enabled.
+      bit_offset: 19
+      bit_size: 1
+    - name: IREF_INC
+      description: Reference current state selection.  for pins PD PHY and bc.
+      bit_offset: 20
+      bit_size: 1

--- a/data/registers/usbpd_ch641.yaml
+++ b/data/registers/usbpd_ch641.yaml
@@ -40,20 +40,14 @@ block/USBPD:
     byte_offset: 10
     bit_size: 16
     fieldset: BMC_BYTE_CNT
-  - name: PORT_CC1
-    description: CC1 port control register.
+  # CC1: offset: 12, CC2: offset: 14, CC3: offset: 15
+  - name: PORT_CC
+    description: CC port control register.
     byte_offset: 12
     bit_size: 8
-    fieldset: PORT_CC
-  - name: PORT_CC2
-    description: CC2 port control register.
-    byte_offset: 14
-    bit_size: 8
-    fieldset: PORT_CC
-  - name: PORT_CC3
-    description: CC3 port control register.
-    byte_offset: 15
-    bit_size: 8
+    array:
+      len: 4
+      stride: 1
     fieldset: PORT_CC
   - name: DMA
     description: PD buffer start address register.

--- a/data/registers/usbpd_ch641.yaml
+++ b/data/registers/usbpd_ch641.yaml
@@ -1,4 +1,4 @@
-block/USB_PD:
+block/USBPD:
   description: USBPD configuration.
   items:
   - name: CONFIG
@@ -99,6 +99,7 @@ fieldset/CONFIG:
     description: PD Commutation port.
     bit_offset: 2
     bit_size: 2
+    enum: CC_SEL
   - name: PD_DMA_EN
     description: PD DMA Enable.
     bit_offset: 4
@@ -167,7 +168,7 @@ fieldset/PORT_CC:
   description: CC port control register.
   bit_size: 8
   fields:
-  - name: CC_CMP0
+  - name: PA_CC_AI
     description: CC1 output of the voltage comparator.
     bit_offset: 0
     bit_size: 1
@@ -184,15 +185,11 @@ fieldset/PORT_CC:
     description: CC1 port output of the low voltage.
     bit_offset: 4
     bit_size: 1
-  - name: CC_CVS
-    description: CC1 voltage comparator reference voltage.
-    bit_offset: 5
-    bit_size: 2
-    enum: PORT_CC_CVS
   - name: CC_CE
-    description: CC1 voltage comparator enable.
-    bit_offset: 7
-    bit_size: 1
+    description: CC1 voltage comparator enable and voltage comparator reference voltage. (CC_CE and CC_CVS)
+    bit_offset: 5
+    bit_size: 3
+    enum: PORT_CC_CE
 fieldset/STATUS:
   description: PD interrupt flag register.
   bit_size: 8
@@ -246,22 +243,37 @@ fieldset/TX_SEL:
     description: K-CODE4 type selection.
     bit_offset: 6
     bit_size: 2
-enum/PORT_CC_CVS:
-  descrption: CC voltage comparator reference voltage.
+enum/CC_SEL:
   bit_size: 2
   variants:
+  - name: CC1
+    description: Select CC1.
+    value: 0b00
+  - name: CC2
+    description: Select CC2.
+    value: 0b01
+  - name: CC3
+    description: Select CC3.
+    value: 0b10
+enum/PORT_CC_CE:
+  descrption: CC voltage comparator reference voltage.
+  bit_size: 3
+  variants:
+  - name: Closed
+    description: No pull up current.
+    value: 0b000
   - name: V0_55
     description: 0.55V
-    value: 0b00
+    value: 0b100
   - name: V0_22
     description: 0.22V
-    value: 0b01
+    value: 0b101
   - name: V0_66
     description: 0.66V
-    value: 0b10
+    value: 0b110
   - name: V1_23
     description: 1.23V
-    value: 0b11
+    value: 0b111
 enum/PORT_CC_PU:
   bit_size: 2
   variants:

--- a/data/registers/usbpd_l1.yaml
+++ b/data/registers/usbpd_l1.yaml
@@ -40,15 +40,14 @@ block/USBPD:
     byte_offset: 10
     bit_size: 16
     fieldset: BMC_BYTE_CNT
-  - name: PORT_CC1
-    description: CC1 port control register.
+  # CC1: offset: 12, CC2: offset: 14
+  - name: PORT_CC
+    description: CC port control register.
     byte_offset: 12
-    bit_size: 16
-    fieldset: PORT_CC
-  - name: PORT_CC2
-    description: CC2 port control register.
-    byte_offset: 14
-    bit_size: 16
+    bit_size: 8
+    array: #
+      len: 4
+      stride: 1
     fieldset: PORT_CC
   - name: DMA
     description: PD buffer start address register.
@@ -162,7 +161,7 @@ fieldset/CONTROL:
     bit_size: 1
 fieldset/PORT_CC:
   description: CC1 port control register.
-  bit_size: 16
+  bit_size: 8
   fields:
   - name: PA_CC_AI
     description: CC port comparator analog input.

--- a/data/registers/usbpd_x0.yaml
+++ b/data/registers/usbpd_x0.yaml
@@ -40,15 +40,14 @@ block/USBPD:
     byte_offset: 10
     bit_size: 16
     fieldset: BMC_BYTE_CNT
-  - name: PORT_CC1
-    description: CC1 port control register.
+  # CC1: offset: 12, CC2: offset: 14
+  - name: PORT_CC
+    description: CC port control register.
     byte_offset: 12
-    bit_size: 16
-    fieldset: PORT_CC
-  - name: PORT_CC2
-    description: CC2 port control register.
-    byte_offset: 14
-    bit_size: 16
+    bit_size: 8
+    array: #
+      len: 4
+      stride: 1
     fieldset: PORT_CC
   - name: DMA
     description: PD buffer start address register.


### PR DESCRIPTION
Changes:

- Split CH641 register blocks from CH32V0 series
- Refine USB PD register blocks for CH32X0, CH32L1, CH641: a unified approach to handle CC1/CC2/CC3 pins