### PR TITLE
fix(otg_v2): correct UEP_DMA bit_size from 16 to 32

### DIFF
--- a/data/registers/otg_v2.yaml
+++ b/data/registers/otg_v2.yaml
@@ -82,7 +82,7 @@ block/USBD:
     - name: UEP_DMA
       description: endpoint DMA buffer address.
       byte_offset: 16
-      bit_size: 16
+      bit_size: 32
       array:
         len: 8
         stride: 4


### PR DESCRIPTION
Fix applied according to the datasheet.