### PR TITLE
CH32V20x: Update USBFS interrupt naming

### DIFF
--- a/data/peripherals/FV2x_V3x_USBFS.yaml
+++ b/data/peripherals/FV2x_V3x_USBFS.yaml
@@ -13,7 +13,9 @@
       field: OTG_EN
   interrupts:
     - signal: GLOBAL
-      interrupt: OTG_FS
+      interrupt: USBHD
+    - signal: WAKEUP
+      interrupt: USBHD_WKUP
   pins:
     - pin: PA11
       signal: DM


### PR DESCRIPTION
Made a small mistake earlier, did not actually check that the USB_FS interrupt used by CH32V20x is named differently. This should address that.