### PR TITLE
fix ADC channel 4 pin on CH32V003

### DIFF
--- a/data/family/CH32V0.yaml
+++ b/data/family/CH32V0.yaml
@@ -570,7 +570,7 @@
       signal: IN2
     - pin: PD2
       signal: IN3
-    - pin: PC3
+    - pin: PD3
       signal: IN4
     - pin: PD5
       signal: IN5


### PR DESCRIPTION
Fix https://github.com/ch32-rs/ch32-hal/issues/68

I also tested all the ADC pins on the CH32V003 to be sure.