### PR TITLE
fix(ch643): add missing PIOC interrupt

### DIFF
--- a/data/interrupts/CH643.yaml
+++ b/data/interrupts/CH643.yaml
@@ -60,6 +60,8 @@ DMA1_CHANNEL8: 44
 USBFS: 45
 # 46 - USBFS_WKUP
 USBFS_WKUP: 46
+# 47 - PIOC
+PIOC: 47
 # 49 - USBPD global interrupt
 USBPD: 49
 # 50 - USBPD_WKUP global interrupt


### PR DESCRIPTION
I'm currently working on adding CH643 support to ch32-hal. During testing, I found that the PIOC peripheral in data/family/CH643.yaml references an interrupt that wasn't defined in the interrupt list. This causes build errors in the generated metapac and HAL.

I've added PIOC: 47 to data/interrupts/CH643.yaml according to the datasheet.

Verified by generating the metapac locally and testing it with a blinky example on actual CH643 hardware. The code now compiles and runs correctly.