### PR TITLE
New FLASH registers for CH32V00X

### DIFF
--- a/data/family/CH32V00X.yaml
+++ b/data/family/CH32V00X.yaml
@@ -22,7 +22,7 @@
   address: 0x40022000
   registers:
     kind: flash
-    version: v0
+    version: v00x
     block: FLASH
 - name: EXTI
   address: 0x40010400

--- a/data/registers/flash_v00x.yaml
+++ b/data/registers/flash_v00x.yaml
@@ -1,0 +1,240 @@
+block/FLASH:
+  description: FLASH.
+  items:
+  - name: ACTLR
+    description: Flash ACTL register.
+    byte_offset: 0
+    fieldset: ACTLR
+  - name: KEYR
+    description: Flash key register.
+    byte_offset: 4
+    access: Write
+    fieldset: KEYR
+  - name: OBKEYR
+    description: Flash option key register.
+    byte_offset: 8
+    access: Write
+    fieldset: OBKEYR
+  - name: STATR
+    description: Status register.
+    byte_offset: 12
+    fieldset: STATR
+  - name: CTLR
+    description: Control register.
+    byte_offset: 16
+    fieldset: CTLR
+  - name: ADDR
+    description: Flash address register.
+    byte_offset: 20
+    access: Write
+    fieldset: ADDR
+  - name: OBR
+    description: Option byte register.
+    byte_offset: 28
+    access: Read
+    fieldset: OBR
+  - name: WPR
+    description: Write protection register.
+    byte_offset: 32
+    access: Read
+    fieldset: WPR
+  - name: MODEKEYR
+    description: Mode select register.
+    byte_offset: 36
+    access: Write
+    fieldset: MODEKEYR
+  - name: BOOT_MODEKEYP
+    description: BOOT Mode select register.
+    byte_offset: 40
+    access: Write
+    fieldset: BOOT_MODEKEYP
+fieldset/ACTLR:
+  description: Flash ACTL register.
+  fields:
+  - name: LATENCY
+    description: LATENCY.
+    bit_offset: 0
+    bit_size: 2
+fieldset/ADDR:
+  description: Flash address register.
+  fields:
+  - name: FAR
+    description: Flash Address.
+    bit_offset: 0
+    bit_size: 32
+fieldset/BOOT_MODEKEYP:
+  description: BOOT Mode select register.
+  fields:
+  - name: MODEKEYR
+    description: Mode select.
+    bit_offset: 0
+    bit_size: 32
+fieldset/CTLR:
+  description: Control register.
+  fields:
+  - name: PER
+    description: Page Erase.
+    bit_offset: 1
+    bit_size: 1
+  - name: MER
+    description: Mass Erase.
+    bit_offset: 2
+    bit_size: 1
+  - name: OBPG
+    description: Option byte programming.
+    bit_offset: 4
+    bit_size: 1
+  - name: OBER
+    description: Option byte erase.
+    bit_offset: 5
+    bit_size: 1
+  - name: STRT
+    description: Start.
+    bit_offset: 6
+    bit_size: 1
+  - name: LOCK
+    description: Lock.
+    bit_offset: 7
+    bit_size: 1
+  - name: OBWRE
+    description: Option bytes write enable.
+    bit_offset: 9
+    bit_size: 1
+  - name: ERRIE
+    description: Error interrupt enable.
+    bit_offset: 10
+    bit_size: 1
+  - name: EOPIE
+    description: End of operation interrupt enable.
+    bit_offset: 12
+    bit_size: 1
+  - name: FWAKEIE
+    description: Wakeup enable.
+    bit_offset: 13
+    bit_size: 1
+  - name: FLOCK
+    description: Fast programmable lock.
+    bit_offset: 15
+    bit_size: 1
+  - name: FTPG
+    description: Fast programming.
+    bit_offset: 16
+    bit_size: 1
+  - name: FTER
+    description: Fast erase.
+    bit_offset: 17
+    bit_size: 1
+  - name: BUFLOAD
+    description: BUFLOAD.
+    bit_offset: 18
+    bit_size: 1
+  - name: BUFRST
+    description: BUFRST.
+    bit_offset: 19
+    bit_size: 1
+  - name: BER32
+    description: BER32.
+    bit_offset: 23
+    bit_size: 1
+fieldset/KEYR:
+  description: Flash key register.
+  fields:
+  - name: KEYR
+    description: FPEC key.
+    bit_offset: 0
+    bit_size: 32
+fieldset/MODEKEYR:
+  description: Mode select register.
+  fields:
+  - name: MODEKEYR
+    description: Mode select.
+    bit_offset: 0
+    bit_size: 32
+fieldset/OBKEYR:
+  description: Flash option key register.
+  fields:
+  - name: OPTKEY
+    description: Option byte key.
+    bit_offset: 0
+    bit_size: 32
+fieldset/OBR:
+  description: Option byte register.
+  fields:
+  - name: OBERR
+    description: Option byte error.
+    bit_offset: 0
+    bit_size: 1
+  - name: RDPRT
+    description: Read protection.
+    bit_offset: 1
+    bit_size: 1
+  - name: IWDG_SW
+    description: IWDG_SW.
+    bit_offset: 2
+    bit_size: 1
+  - name: STOP_RST
+    description: STOP_RST.
+    bit_offset: 3
+    bit_size: 1
+  - name: STANDY_RST
+    description: STANDY_RST.
+    bit_offset: 4
+    bit_size: 1
+  - name: CFGRSTT
+    description: Config reset delay time.
+    bit_offset: 5
+    bit_size: 2
+  - name: DATA0
+    description: DATA0.
+    bit_offset: 10
+    bit_size: 8
+  - name: DATA1
+    description: DATA1.
+    bit_offset: 18
+    bit_size: 8
+fieldset/STATR:
+  description: Status register.
+  fields:
+  - name: BSY
+    description: Busy.
+    bit_offset: 0
+    bit_size: 1
+  - name: WRPRTERR
+    description: Write protection error.
+    bit_offset: 4
+    bit_size: 1
+  - name: EOP
+    description: End of operation.
+    bit_offset: 5
+    bit_size: 1
+  - name: FWAKE_FLAG
+    description: FWAKE_FLAG mode start.
+    bit_offset: 6
+    bit_size: 1
+  - name: TURBO
+    description: TURBO mode start.
+    bit_offset: 7
+    bit_size: 1
+  - name: BOOT_AVA
+    description: BOOT_AVA.
+    bit_offset: 12
+    bit_size: 1
+  - name: BOOT_STATUS
+    description: BOOT_STATUS.
+    bit_offset: 13
+    bit_size: 1
+  - name: BOOT_MODE
+    description: BOOT_MODE.
+    bit_offset: 14
+    bit_size: 1
+  - name: BOOT_LOCK
+    description: BOOT_LOCK.
+    bit_offset: 15
+    bit_size: 1
+fieldset/WPR:
+  description: Write protection register.
+  fields:
+  - name: WRP
+    description: Write protect.
+    bit_offset: 0
+    bit_size: 32

--- a/data/registers/flash_v00x.yaml
+++ b/data/registers/flash_v00x.yaml
@@ -180,6 +180,10 @@ fieldset/OBR:
     description: Config reset delay time.
     bit_offset: 5
     bit_size: 2
+  - name: STATR_MODE
+    description: "Power-on startup mode: 1: Startup from BOOT area; 0: Startup from user area."
+    bit_offset: 7
+    bit_size: 1
   - name: DATA0
     description: DATA0.
     bit_offset: 10

--- a/data/registers/flash_v00x.yaml
+++ b/data/registers/flash_v00x.yaml
@@ -172,10 +172,6 @@ fieldset/OBR:
     description: IWDG_SW.
     bit_offset: 2
     bit_size: 1
-  - name: STOP_RST
-    description: STOP_RST.
-    bit_offset: 3
-    bit_size: 1
   - name: STANDY_RST
     description: STANDY_RST.
     bit_offset: 4

--- a/data/registers/flash_v00x.yaml
+++ b/data/registers/flash_v00x.yaml
@@ -80,10 +80,6 @@ fieldset/CTLR:
     description: Mass Erase.
     bit_offset: 2
     bit_size: 1
-  - name: OBPG
-    description: Option byte programming.
-    bit_offset: 4
-    bit_size: 1
   - name: OBER
     description: Option byte erase.
     bit_offset: 5


### PR DESCRIPTION
I noticed that CH32V00X is using V003's flash register definition (`flash_v0.yaml`), but this is incorrect, V00X has an almost identical flash controller design as the CH32X series with a few minor difference outlined below:

- `STATR_MODE` (Bit 7 of `FLASH_OBR`) - only exists in CH32V00X. It is reserved in CH32X series.
- `STOP_RST` (Bit 3 of `FLASH_OBR`) - only exists in CH32X series. It is reserved in CH32V00X series.

I also noticed that current `flash_x0.yaml` defines `OBPG` ( Bit 4 of `FLASH_CTLR` ), but this doesn't exist in CH32V00X.pdf or CH32X035RM.pdf.

**Unrelated, but a potential bug / mistake I noticed while looking at `flash_v0.yaml`:**

`OBPG` ( Bit 4 of `FLASH_CTLR` ) does not exist in CH32V00X or CH32X series. This is available in CH32V003 however, and is used for writing a half word to the OB flash.

If you'd like to change this, I can either remove it in this PR or in a separate PR, your choice. ( Or I can leave it as is, but could be confusing for users, as this function doesn't exist in those chips )

P.s. this is my first time contributing to this repo. I did read the contribution notice, and I will supply evidence in the coming comments.