### PR TITLE
Add quotes and others to prevent word splits

### DIFF
--- a/d
+++ b/d
@@ -2,14 +2,14 @@
 
 set -ex
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 CMD=$1
 shift
 
 case "$CMD" in
     download-all)
-        echo TODO $CMD
+        echo TODO "$CMD"
     ;;
     install-chiptool)
         cargo install --git https://github.com/embassy-rs/chiptool
@@ -17,31 +17,33 @@ case "$CMD" in
     extract-all)
         peri=$1
         shift
-        echo $@
+        echo "$@"
 
-        rm -rf tmp/$peri
-        mkdir -p tmp/$peri
+        rm -rf "tmp/$peri"
+        mkdir -p "tmp/$peri"
 
         for f in `ls svd/ch32*`; do
-            echo $f
-            svd_path=$f
-            f=${f#"svd/ch32"}
-            f=${f%".svd.patched"}
-            echo -n processing $f ...
-            if test -f  transforms/$peri.yaml; then
-                trans_args="--transform transforms/$peri.yaml"
+            echo "$f"
+            svd_path="$f"
+            f="${f#"svd/ch32"}"
+            f="${f%".svd.patched"}"
+            echo -n "processing $f ..."
+
+            trans_args=()
+            if test -f "transforms/$peri.yaml"; then
+                trans_args=(--transform "transforms/$peri.yaml")
             fi
 
-            if chiptool extract-peripheral $trans_args --svd $svd_path --peripheral $peri $@ > tmp/$peri/$f.yaml 2> tmp/$peri/$f.err; then
-                rm tmp/$peri/$f.err
+            if chiptool extract-peripheral "${trans_args[@]}" --svd "$svd_path" --peripheral "$peri" "$@" > "tmp/$peri/$f.yaml" 2> "tmp/$peri/$f.err"; then
+                rm "tmp/$peri/$f.err"
                 echo OK
             else
-                if grep -q 'peripheral not found' tmp/$peri/$f.err; then
+                if grep -q 'peripheral not found' "tmp/$peri/$f.err"; then
                     echo No Peripheral
                 else
                     echo OTHER FAILURE
                 fi
-                rm tmp/$peri/$f.yaml
+                rm "tmp/$peri/$f.yaml"
             fi
         done
     ;;
@@ -51,7 +53,7 @@ case "$CMD" in
         cargo run -p ch32-data-gen && cargo run -p ch32-metapac-gen -- "CH32X03*" "CH32V*" "CH32L*" CH641 CH643
     ;;
     ci)
-        echo TODO $CMD
+        echo TODO "$CMD"
     ;;
     *)
         echo "unknown command"


### PR DESCRIPTION
This PR, as the title suggests, consists of a commit that adds quotes to several variables and refactors flag-passing in the `d` script to prevent potential word splittings in commands that involve variable expansions (related to <https://www.shellcheck.net/wiki/SC2086>).

Consider, for instance, `rm -rf tmp/$peri` on line 22 in the original script. If `peri` is empty, where no argument is passed, then `rm -rf tmp/$peri` would expand to `rm -rf tmp/`, which would wipe the entire `tmp/` system directory unexpectedly. Similarly, if `peri` contains whitespaces, then the unquoted expansion would yield an expression like `rm -rf tmp/some sort of pari`, where `rm` would recursively and forceably remove `tmp/some`, `sort`, `of`, and `pari` as independent paths, which would be unexpected and potentially catastrophic.

Besides, `trans_args`, a variable that is previously stored as a single string for multiple shell words within the if branch (`trans_args="--transform transforms/$peri.yaml"`), is replaced with a Bash array and its usage, since directly quoting `trans_args` as a single string would cause `chiptool` receiving the flag and its vaue as a fused argument (`argv[1] = "--transform transforms/$peri.yaml"` rather than `argv[1] = "--transform"` and `argv[2] = "transforms/$peri.yaml"`). After the changes, `"${trans_args[@]}"` would expand each element as a separate argument, which appropriately handles both the case with no expansion and the case with expansion.