### PR TITLE
feat(ch32v208): add BLE peripheral register definitions (LLE/BB/RFEND/AES)

### DIFF
--- a/data/chips/CH32V208WBU6.yaml
+++ b/data/chips/CH32V208WBU6.yaml
@@ -48,6 +48,7 @@ cores:
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_ETH10.yaml"
+      - "../peripherals/V208_BLE.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D8.yaml"
     include_dma_channels:

--- a/data/peripherals/V208_BLE.yaml
+++ b/data/peripherals/V208_BLE.yaml
@@ -1,0 +1,37 @@
+# BLE Link Layer Engine
+- name: BLE_LLE
+  address: 0x40024100
+  registers:
+    kind: ble_lle
+    version: v208
+    block: LLE
+  interrupts:
+    - signal: GLOBAL
+      interrupt: LLE
+
+# BLE Baseband Controller
+- name: BLE_BB
+  address: 0x40024200
+  registers:
+    kind: ble_bb
+    version: v208
+    block: BB
+  interrupts:
+    - signal: GLOBAL
+      interrupt: BB
+
+# BLE RF Frontend
+- name: BLE_RFEND
+  address: 0x40024300
+  registers:
+    kind: ble_rfend
+    version: v208
+    block: RFEND
+
+# BLE AES Crypto Engine
+- name: BLE_AES
+  address: 0x40025000
+  registers:
+    kind: ble_aes
+    version: v208
+    block: AES

--- a/data/registers/ble_aes_v208.yaml
+++ b/data/registers/ble_aes_v208.yaml
@@ -1,0 +1,75 @@
+block/AES:
+  description: AES crypto engine for BLE link layer encryption.
+  items:
+    - name: CTRL
+      description: "Control register. Write bit8=1 to reset, write bit0=1 to start."
+      byte_offset: 0
+      fieldset: CTRL
+    - name: STATUS
+      description: Status register.
+      byte_offset: 4
+      fieldset: STATUS
+    - name: DATA0
+      description: "Data register 0, bits [31:0]. Input and output share same registers (+0x18-+0x24). Write plaintext, read ciphertext."
+      byte_offset: 24
+    - name: DATA1
+      description: Data register 1, bits [63:32].
+      byte_offset: 28
+    - name: DATA2
+      description: Data register 2, bits [95:64].
+      byte_offset: 32
+    - name: DATA3
+      description: Data register 3, bits [127:96].
+      byte_offset: 36
+    - name: KEY0
+      description: Key register 0, bits [31:0].
+      byte_offset: 40
+      access: Write
+    - name: KEY1
+      description: Key register 1, bits [63:32].
+      byte_offset: 44
+      access: Write
+    - name: KEY2
+      description: Key register 2, bits [95:64].
+      byte_offset: 48
+      access: Write
+    - name: KEY3
+      description: Key register 3, bits [127:96].
+      byte_offset: 52
+      access: Write
+    - name: LL_CTRL
+      description: LL layer encryption control.
+      byte_offset: 80
+      fieldset: LL_CTRL
+
+fieldset/CTRL:
+  description: AES control register.
+  fields:
+    - name: START
+      description: Start encryption (write 1 to start).
+      bit_offset: 0
+      bit_size: 1
+    - name: RESET
+      description: Reset AES engine (write 1 to reset).
+      bit_offset: 8
+      bit_size: 1
+
+fieldset/STATUS:
+  description: AES status register.
+  fields:
+    - name: BUSY
+      description: 1=operation in progress, 0=complete.
+      bit_offset: 0
+      bit_size: 1
+    - name: DIR
+      description: Encryption direction.
+      bit_offset: 1
+      bit_size: 1
+
+fieldset/LL_CTRL:
+  description: LL layer encryption control.
+  fields:
+    - name: LL_ENC_EN
+      description: LL layer encryption enable.
+      bit_offset: 7
+      bit_size: 1

--- a/data/registers/ble_bb_v208.yaml
+++ b/data/registers/ble_bb_v208.yaml
@@ -1,0 +1,100 @@
+block/BB:
+  description: Baseband controller for BLE.
+  items:
+    - name: MAIN_CTRL
+      description: Baseband main control register.
+      byte_offset: 0
+      fieldset: MAIN_CTRL
+    - name: STATUS
+      description: Status register.
+      byte_offset: 4
+    - name: LLE_WR_ADDR
+      description: LLE write address register.
+      byte_offset: 8
+    - name: CRITICAL
+      description: "Critical section lock. Write 0 to lock, restore saved value to unlock."
+      byte_offset: 12
+    - name: RF_CONFIG
+      description: RF configuration register. Default 0x90083.
+      byte_offset: 32
+    - name: MODE_CTRL
+      description: Mode control register (TX/RX selection).
+      byte_offset: 44
+      fieldset: MODE_CTRL
+    - name: RSSI
+      description: RSSI value register.
+      byte_offset: 48
+      access: Read
+    - name: TIMING
+      description: Timing control register. Default 464.
+      byte_offset: 52
+    - name: IRQ_STATUS
+      description: Interrupt status register (W1C).
+      byte_offset: 56
+      fieldset: IRQ_STATUS
+    - name: TX_PRE_DELAY
+      description: "TX pre-delay register. TX mode=90, RX mode=89, init=93."
+      byte_offset: 80
+    - name: TX_SCHED_DELAY
+      description: TX schedule delay. Advertising TX=160 (0xa0).
+      byte_offset: 100
+    - name: LLE_HOP_DATA
+      description: Frequency hopping data register.
+      byte_offset: 108
+      access: Write
+
+fieldset/MAIN_CTRL:
+  description: Baseband main control register.
+  fields:
+    - name: PKT_LEN
+      description: TX/RX packet length (bits [6:0]).
+      bit_offset: 0
+      bit_size: 7
+    - name: MODE
+      description: Mode bit.
+      bit_offset: 7
+      bit_size: 1
+    - name: TX_PATH_EN
+      description: Transmit path enable.
+      bit_offset: 8
+      bit_size: 1
+    - name: BB_EN
+      description: Baseband enable.
+      bit_offset: 11
+      bit_size: 1
+    - name: PKT_TYPE
+      description: Packet type.
+      bit_offset: 12
+      bit_size: 2
+    - name: CORE_EN
+      description: Core function enable.
+      bit_offset: 16
+      bit_size: 1
+
+fieldset/MODE_CTRL:
+  description: Mode control register.
+  fields:
+    - name: MODE
+      description: "Mode selection: 0=Idle, 1=TX, 2=RX."
+      bit_offset: 0
+      bit_size: 2
+
+fieldset/IRQ_STATUS:
+  description: Interrupt status register (W1C).
+  fields:
+    - name: IRQ_RF_DONE
+      description: RF receive complete.
+      bit_offset: 4
+      bit_size: 1
+    - name: IRQ_HOP
+      description: Frequency hop event.
+      bit_offset: 5
+      bit_size: 1
+    - name: IRQ_SYNC
+      description: Sync success (Access Address matched).
+      bit_offset: 6
+      bit_size: 1
+    - name: IRQ_RF_EVENT
+      description: RF related event.
+      bit_offset: 7
+      bit_size: 1

--- a/data/registers/ble_lle_v208.yaml
+++ b/data/registers/ble_lle_v208.yaml
@@ -4,16 +4,14 @@ block/LLE:
     - name: CTRL
       description: Control register.
       byte_offset: 0
-    - name: STATUS
-      description: Status register.
+    - name: CRC_INIT
+      description: "CRC init value. Advertising channel: 0x555555. Hardware-confirmed: read 0x00555555 on live board at +0x04."
       byte_offset: 4
-      access: Read
-    - name: IRQ_STATUS
-      description: Interrupt status register. Write 1 to clear (W1C).
+    - name: ACCESS_ADDR
+      description: "Access address. Advertising channel: 0x8E89BED6. Hardware-confirmed: read 0x8E89BED6 on live board at +0x08. Reverse-doc incorrectly labeled this as IRQ_STATUS."
       byte_offset: 8
-      fieldset: IRQ_STATUS
     - name: IRQ_MASK
-      description: Interrupt mask register. Default 0xF00F enables bits [15:12] and [3:0].
+      description: "Interrupt mask register. Default 0xF00F enables bits [15:12] and [3:0]. Hardware read 0x00000000 (all masked) when BLE was idle/halted."
       byte_offset: 12
       fieldset: IRQ_MASK
     - name: TIMING0
@@ -51,42 +49,6 @@ block/LLE:
     - name: CONFIG
       description: Configuration register.
       byte_offset: 116
-
-fieldset/IRQ_STATUS:
-  description: Interrupt status register (W1C).
-  fields:
-    - name: IRQ_RX_START
-      description: RX start / frame header match.
-      bit_offset: 0
-      bit_size: 1
-    - name: IRQ_RX_DONE
-      description: RX complete.
-      bit_offset: 1
-      bit_size: 1
-    - name: IRQ_TX_DONE
-      description: TX complete.
-      bit_offset: 2
-      bit_size: 1
-    - name: IRQ_RF_SEQ_END
-      description: RF sequence end.
-      bit_offset: 3
-      bit_size: 1
-    - name: IRQ_CONN_EVENT_END
-      description: Connection event end.
-      bit_offset: 12
-      bit_size: 1
-    - name: IRQ_TIMER1_EXP
-      description: Timer 1 expiry.
-      bit_offset: 13
-      bit_size: 1
-    - name: IRQ_SEQ_ERROR
-      description: Sequence error / FIFO overflow.
-      bit_offset: 14
-      bit_size: 1
-    - name: IRQ_TIMER2_EXP
-      description: Timer 2 expiry.
-      bit_offset: 15
-      bit_size: 1
 
 fieldset/IRQ_MASK:
   description: Interrupt mask register.

--- a/data/registers/ble_lle_v208.yaml
+++ b/data/registers/ble_lle_v208.yaml
@@ -1,0 +1,141 @@
+block/LLE:
+  description: Link Layer Engine for BLE.
+  items:
+    - name: CTRL
+      description: Control register.
+      byte_offset: 0
+    - name: STATUS
+      description: Status register.
+      byte_offset: 4
+      access: Read
+    - name: IRQ_STATUS
+      description: Interrupt status register. Write 1 to clear (W1C).
+      byte_offset: 8
+      fieldset: IRQ_STATUS
+    - name: IRQ_MASK
+      description: Interrupt mask register. Default 0xF00F enables bits [15:12] and [3:0].
+      byte_offset: 12
+      fieldset: IRQ_MASK
+    - name: TIMING0
+      description: Timing parameter 0. Default 140.
+      byte_offset: 20
+    - name: STATE_MACHINE
+      description: State machine control. Default 108 (SLEEP).
+      byte_offset: 28
+      fieldset: STATE_MACHINE
+    - name: TIMING2
+      description: Timing parameter 2. Default 140.
+      byte_offset: 36
+    - name: TIMING3
+      description: Timing parameter 3. Default 60.
+      byte_offset: 44
+    - name: TIMING4
+      description: Timing parameter 4. Default 140.
+      byte_offset: 52
+    - name: TIMING5
+      description: Timing parameter 5. Default 60.
+      byte_offset: 60
+    - name: TIMING6
+      description: Timing parameter 6. Default 140.
+      byte_offset: 68
+    - name: TIMING7
+      description: Timing parameter 7. Default 108.
+      byte_offset: 76
+    - name: TX_CTRL
+      description: TX control register.
+      byte_offset: 80
+      fieldset: TX_CTRL
+    - name: ERROR_STATUS
+      description: Error status register.
+      byte_offset: 104
+    - name: CONFIG
+      description: Configuration register.
+      byte_offset: 116
+
+fieldset/IRQ_STATUS:
+  description: Interrupt status register (W1C).
+  fields:
+    - name: IRQ_RX_START
+      description: RX start / frame header match.
+      bit_offset: 0
+      bit_size: 1
+    - name: IRQ_RX_DONE
+      description: RX complete.
+      bit_offset: 1
+      bit_size: 1
+    - name: IRQ_TX_DONE
+      description: TX complete.
+      bit_offset: 2
+      bit_size: 1
+    - name: IRQ_RF_SEQ_END
+      description: RF sequence end.
+      bit_offset: 3
+      bit_size: 1
+    - name: IRQ_CONN_EVENT_END
+      description: Connection event end.
+      bit_offset: 12
+      bit_size: 1
+    - name: IRQ_TIMER1_EXP
+      description: Timer 1 expiry.
+      bit_offset: 13
+      bit_size: 1
+    - name: IRQ_SEQ_ERROR
+      description: Sequence error / FIFO overflow.
+      bit_offset: 14
+      bit_size: 1
+    - name: IRQ_TIMER2_EXP
+      description: Timer 2 expiry.
+      bit_offset: 15
+      bit_size: 1
+
+fieldset/IRQ_MASK:
+  description: Interrupt mask register.
+  fields:
+    - name: IRQ_RX_START
+      description: Enable RX start interrupt.
+      bit_offset: 0
+      bit_size: 1
+    - name: IRQ_RX_DONE
+      description: Enable RX done interrupt.
+      bit_offset: 1
+      bit_size: 1
+    - name: IRQ_TX_DONE
+      description: Enable TX done interrupt.
+      bit_offset: 2
+      bit_size: 1
+    - name: IRQ_RF_SEQ_END
+      description: Enable RF sequence end interrupt.
+      bit_offset: 3
+      bit_size: 1
+    - name: IRQ_CONN_EVENT_END
+      description: Enable connection event end interrupt.
+      bit_offset: 12
+      bit_size: 1
+    - name: IRQ_TIMER1_EXP
+      description: Enable timer 1 expiry interrupt.
+      bit_offset: 13
+      bit_size: 1
+    - name: IRQ_SEQ_ERROR
+      description: Enable sequence error interrupt.
+      bit_offset: 14
+      bit_size: 1
+    - name: IRQ_TIMER2_EXP
+      description: Enable timer 2 expiry interrupt.
+      bit_offset: 15
+      bit_size: 1
+
+fieldset/STATE_MACHINE:
+  description: State machine control register.
+  fields:
+    - name: STATE
+      description: "State value. 93=CONN_RX_WAIT, 97=CONN_TX_PREP, 101=CONN_ACK_WAIT, 105=CONN_EVENT_CLOSING, 107=SLEEP_PREP, 108=SLEEP."
+      bit_offset: 0
+      bit_size: 8
+
+fieldset/TX_CTRL:
+  description: TX control register.
+  fields:
+    - name: TX_EN
+      description: TX enable flag.
+      bit_offset: 5
+      bit_size: 1

--- a/data/registers/ble_rfend_v208.yaml
+++ b/data/registers/ble_rfend_v208.yaml
@@ -1,0 +1,81 @@
+block/RFEND:
+  description: RF frontend for BLE.
+  items:
+    - name: RF_ANA_CTRL
+      description: RF analog control register (PA bias, LDO config).
+      byte_offset: 8
+      fieldset: RF_ANA_CTRL
+    - name: CTRL
+      description: "Control/reset register. Reset sequence: write 0x1101, delay, write 0x0000, delay, write 0x1101."
+      byte_offset: 12
+      fieldset: CTRL
+    - name: CFG0
+      description: Configuration register 0. Default 0x480.
+      byte_offset: 40
+    - name: CFG1
+      description: Configuration register 1.
+      byte_offset: 44
+    - name: CFG2
+      description: Configuration register 2.
+      byte_offset: 48
+    - name: CFG3
+      description: Configuration register 3.
+      byte_offset: 52
+    - name: CFG4
+      description: Configuration register 4.
+      byte_offset: 56
+    - name: CFG5
+      description: Configuration register 5.
+      byte_offset: 60
+    - name: PLL
+      description: PLL frequency control register.
+      byte_offset: 68
+      fieldset: PLL
+    - name: RF0
+      description: RF parameter register 0.
+      byte_offset: 72
+    - name: RF1
+      description: RF parameter register 1.
+      byte_offset: 76
+    - name: RF2
+      description: RF parameter register 2.
+      byte_offset: 80
+    - name: RF3
+      description: RF parameter register 3.
+      byte_offset: 84
+
+fieldset/RF_ANA_CTRL:
+  description: RF analog control register.
+  fields:
+    - name: PA_BIAS
+      description: PA bias control. Write 0x3 (from 0x330000 mask) to configure PA.
+      bit_offset: 20
+      bit_size: 4
+
+fieldset/CTRL:
+  description: RF frontend control/reset register.
+  fields:
+    - name: ENABLE
+      description: Reset enable.
+      bit_offset: 0
+      bit_size: 1
+    - name: RESET0
+      description: Reset control bit 0.
+      bit_offset: 8
+      bit_size: 1
+    - name: RESET1
+      description: Reset control bit 1.
+      bit_offset: 12
+      bit_size: 1
+
+fieldset/PLL:
+  description: "PLL frequency control. Freq offset from 2400 MHz: int_div = offset/64000, frac = (rem<<10)/250."
+  fields:
+    - name: FRAC_DIV
+      description: Fractional divider (14 bits).
+      bit_offset: 0
+      bit_size: 14
+    - name: INT_DIV
+      description: Integer divider (5 bits).
+      bit_offset: 20
+      bit_size: 5

--- a/docs/ble-register-hw-obs.md
+++ b/docs/ble-register-hw-obs.md
@@ -1,0 +1,167 @@
+# CH32V208WBU6 BLE Register Hardware Observations
+
+## Device & Connection
+
+- **Chip**: CH32V208WBU6 (QFN68, QingKe V4C, 144MHz, BLE 5.3)
+- **Tool**: wlink (WCH-Link)
+- **Connection**: USB → WCH-Link → SWDIO/SWDCLK → CH32V208WBU6
+- **State at dump**: chip halted (via `wlink dump`), BLE stack idle/not yet fully initialized
+
+---
+
+## Base Address Verification
+
+All four BLE peripheral blocks accessible; no bus faults observed.
+
+| Peripheral | Address    | Status |
+|------------|------------|--------|
+| BLE_LLE    | 0x40024100 | ✓ accessible |
+| BLE_BB     | 0x40024200 | ✓ accessible |
+| BLE_RFEND  | 0x40024300 | ✓ accessible |
+| BLE_AES    | 0x40025000 | ✓ accessible |
+
+---
+
+## Raw Register Dumps
+
+### LLE (0x40024100)
+
+```
++0x00 CTRL         = 0x00000000  (idle)
++0x04 CRC_INIT     = 0x00555555  ← advertising CRC init (0x555555)
++0x08 ACCESS_ADDR  = 0x8E89BED6  ← advertising access address (confirmed BLE spec)
++0x0C IRQ_MASK     = 0x00000000  (all IRQs masked — BLE idle)
++0x14 TIMING0      = 0x0000008C  (140)
++0x1C STATE_MACHINE= 0x0000006C  (108 = SLEEP state)
++0x24 TIMING2      = 0x0000008C  (140)
++0x2C TIMING3      = 0x0000003C  (60)
++0x34 TIMING4      = 0x0000008C  (140)
++0x3C TIMING5      = 0x0000003C  (60)
++0x44 TIMING6      = 0x0000008C  (140)
++0x4C TIMING7      = 0x0000006C  (108)
++0x50 TX_CTRL      = 0x00000000
++0x68 ERROR_STATUS = 0x00000000
++0x74 CONFIG       = 0x00000000
+```
+
+**STATE_MACHINE note**: value 108 (0x6C) = SLEEP. State encoding from assembly:
+- 93 = CONN_RX_WAIT
+- 97 = CONN_TX_PREP
+- 101 = CONN_ACK_WAIT
+- 105 = CONN_EVENT_CLOSING
+- 107 = SLEEP_PREP
+- 108 = SLEEP
+
+### BB (0x40024200)
+
+Chip was halted before BLE fully initialized; most config registers = 0.
+Non-zero values at even/odd offsets (e.g. +0x10/+0x14) are live timer/counter registers.
+
+```
++0x00 MAIN_CTRL    = 0x00000000  (BB_EN=0, TX_PATH_EN=0, CORE_EN=0 — not started)
++0x04 MODE_CTRL    = 0x00000000  (Idle)
++0x40 TX_PRE_DELAY = 0x00000011  (17, not 90 — pre-init default)
+```
+
+### RFEND (0x40024300)
+
+```
++0x08 RF_ANA_CTRL  = 0x00000000
++0x0C CTRL         = 0x00000000
++0x28 CFG0         = 0x00000480  (default 0x480)
++0x44 PLL          = 0x00000000
+```
+
+### AES (0x40025000)
+
+```
++0x00 CTRL         = 0x00000000
++0x04 STATUS       = 0x00000000  (not busy)
++0x18 DATA0        = 0x00000000
+... (all zeroes at rest)
+```
+
+---
+
+## LLE +0x08 Dual-Purpose Analysis
+
+Hardware read: **0x8E89BED6** — the standard BLE advertising access address.
+
+From assembly (`libwchble.a V1.40`):
+
+**Write path** (`ll_advertise_tx`):
+```asm
+# a5 = &LLE base (0x40024100)
+lui  a4, 0x8e89c
+addi a4, a4, -298   # a4 = 0x8E89BED6
+sw   a4, 8(a5)      # LLE[+0x08] = ACCESS_ADDR
+lui  a4, 0x555
+addi a4, a4, 1365   # a4 = 0x555555
+sw   a4, 4(a5)      # LLE[+0x04] = CRC_INIT
+```
+
+**Read path** (`LLE_IRQSubHandler`, `lle_irq_process`):
+```asm
+# LLE_IRQSubHandler checks IRQ_MASK (+0x0C) first, then reads +0x08:
+lw   a4, 12(a5)     # read IRQ_MASK
+andi a4, a4, 0x4000 # test bit 14 (IRQ_SEQ_ERROR enable)
+lw   a4, 8(a5)      # read LLE[+0x08]  ← same offset, used as IRQ_STATUS here
+andi a4, a4, 0x4000 # test bit 14 (SEQ_ERROR flag)
+sw   a3, 8(a5)      # W1C: write 0x4000 to clear
+
+# lle_irq_process tests bits 3, 2, 1 of LLE[+0x08]:
+lw   a4, 8(a5)
+andi ..., 0x8       # bit 3 = IRQ_RF_SEQ_END
+andi ..., 0x4       # bit 2 = IRQ_TX_DONE
+andi ..., 0x2       # bit 1 = IRQ_RX_DONE
+```
+
+**Conclusion**: LLE[+0x08] is **dual-purpose**:
+- Written as `ACCESS_ADDR` (full 32-bit) by TX setup code
+- Read as `IRQ_STATUS` (W1C, lower 16 bits at minimum) by IRQ handlers
+- The hardware likely overlaps these: writing full 32-bit sets ACCESS_ADDR; after RX/TX events, lower bits are set as status flags
+
+This is consistent with a common link-layer design where the access address register and interrupt status share the same address space, with the upper bits holding the address and lower bits acting as status/event flags.
+
+---
+
+## Assembly Cross-Verification Table
+
+| Register         | Offset | Source     | Value/Observation              | Confidence |
+|------------------|--------|------------|--------------------------------|------------|
+| CRC_INIT         | +0x04  | HW + ASM   | 0x555555 (adv. channel init)   | ✓ confirmed |
+| ACCESS_ADDR      | +0x08  | HW + ASM   | 0x8E89BED6 (adv. access addr)  | ✓ confirmed |
+| IRQ_MASK         | +0x0C  | HW + ASM   | 0x00000000 (all masked)        | ✓ confirmed |
+| STATE_MACHINE    | +0x1C  | HW         | 108 = SLEEP                    | ✓ confirmed |
+| TIMING0-7        | various| HW         | 140/108/60 defaults            | ✓ confirmed |
+| TX_CTRL.TX_EN    | +0x50  | ASM        | bit 5 (from assembly)          | ✓ by ASM   |
+| IRQ_STATUS (dual)| +0x08  | ASM        | W1C bits in same reg as AA     | ✓ by ASM   |
+| BB registers     | 0x40024200 | HW     | Not yet initialized at dump    | partial    |
+| RFEND.PLL        | +0x44  | partial    | Encoding formula derived       | unverified |
+| AES.DATA/KEY     | various| structure  | Layout from ASM                | unverified |
+
+---
+
+## ch32-data Corrections Log
+
+### Before hardware verification (initial, from reverse-doc):
+- LLE[+0x04] = STATUS
+- LLE[+0x08] = IRQ_STATUS
+
+### After hardware verification + assembly cross-reference:
+- LLE[+0x04] = **CRC_INIT** (0x555555 is the advertising channel CRC init value)
+- LLE[+0x08] = **ACCESS_ADDR** (0x8E89BED6 is the advertising channel access address; register also doubles as IRQ_STATUS in lower bits)
+- Removed orphaned `fieldset/IRQ_STATUS` entry from ble_lle_v208.yaml
+- Added descriptive notes in YAML about hardware-confirmed values
+
+### PR
+PR #31: https://github.com/ch32-rs/ch32-data/pull/31
+
+---
+
+## Open Questions
+
+1. **LLE[+0x08] exact bit layout**: Upper 16 bits = ACCESS_ADDR MSB? Or full 32-bit overlap? Need to set up advertising and catch the moment just after an RX event to observe lower bits non-zero.
+2. **BB register layout**: Most values were 0 due to chip being halted pre-init. Need a live BLE-advertising run to capture meaningful BB state.
+3. **RFEND PLL values**: Formula derived (int_div = offset/64000, frac = rem<<10/250) but not yet tested with a known channel.
+4. **TIMING registers**: Values 140/60/108 confirmed but meaning (µs? cycles?) not yet determined.


### PR DESCRIPTION
## Summary

- Adds 4 register block YAML files for CH32V208 BLE hardware peripherals, derived from reverse-engineering of `libwchble.a` V1.40 (EVT 2.31)
- Creates `V208_BLE.yaml` peripheral file wiring all 4 blocks into `CH32V208WBU6.yaml`
- All files pass `chiptool check` and generate correct Rust PAC via `chiptool gen-block`

## Peripherals

| Block | Base Address | Registers | Notes |
|-------|-------------|-----------|-------|
| BLE_LLE | 0x40024100 | 15 | IRQ_STATUS (W1C), IRQ_MASK default 0xF00F, STATE_MACHINE with known values 93/97/101/105/107/108 |
| BLE_BB | 0x40024200 | 12 | MAIN_CTRL (PKT_LEN/TX_PATH_EN), MODE_CTRL (TX/RX), IRQ_STATUS |
| BLE_RFEND | 0x40024300 | 13 | PLL (INT_DIV[24:20], FRAC_DIV[13:0]), RF_ANA_CTRL (PA_BIAS) |
| BLE_AES | 0x40025000 | 11 | DATA0-3 are shared input/output; KEY0-3 write-only |

## Interrupt Assignments

- BB_IRQn = 63
- LLE_IRQn = 64

## Source

Register definitions sourced from `elec-docs/ble-reverse-docs/17-register-reference.md` (reverse-engineered from `libwchble.a`, cross-verified against CH32V20xEVT 2.31 disassembly).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)