### PR TITLE
feat(ble): add CH32V208 BLE peripheral metadata (BB/LLE/RFEND/AES)

### DIFF
--- a/data/chips/CH32V208WBU6.yaml
+++ b/data/chips/CH32V208WBU6.yaml
@@ -48,6 +48,13 @@ cores:
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_ETH10.yaml"
+      # BLE peripherals — scoped to the bits/offsets exercised by the working
+      # ch32-hal BLE examples (advertising TX + scan RX). Remaining offsets are
+      # left as u32 placeholders so the block layout stays addressable.
+      - "../peripherals/V208_BLE_BB.yaml"
+      - "../peripherals/V208_BLE_LLE.yaml"
+      - "../peripherals/V208_BLE_RFEND.yaml"
+      - "../peripherals/V208_BLE_AES.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D8.yaml"
     include_dma_channels:

--- a/data/peripherals/V208_BLE_AES.yaml
+++ b/data/peripherals/V208_BLE_AES.yaml
@@ -1,0 +1,10 @@
+# CH32V208 BLE AES Engine (gptrAESReg) — only +0x04 cleanup decoded.
+#
+# RCC clocks: AHBPCENR bits 6/16/17 — see V208_BLE_BB.yaml note.
+# Note: full register map TBD; only matters when AES-CCM landed for connection mode.
+- name: BLE_AES
+  address: 0x40024300
+  registers:
+    kind: bleaes
+    version: v208
+    block: BLE_AES

--- a/data/peripherals/V208_BLE_BB.yaml
+++ b/data/peripherals/V208_BLE_BB.yaml
@@ -1,0 +1,17 @@
+# CH32V208 BLE Baseband (gptrBBReg) — link-layer CTRL/GO + IRQ STATUS.
+#
+# RCC clocks: AHBPCENR bits 6 (CRC) + 16 (BLEC) + 17 (BLES) must all be enabled
+# before BB register writes. Currently NOT modeled in rcc_v3.yaml because bit 16
+# is BLEC on V208 but ETHMACRXEN on V307 (shared rcc version). Users set these
+# bits manually via raw register access (see ch32-hal::ble::ble_hw_preamble).
+#
+# IRQ: BB at PFIC vector 63 (defined in interrupts/CH32V2_D8.yaml).
+- name: BLE_BB
+  address: 0x40024100
+  registers:
+    kind: blebb
+    version: v208
+    block: BLE_BB
+  interrupts:
+    - signal: GLOBAL
+      interrupt: BB

--- a/data/peripherals/V208_BLE_LLE.yaml
+++ b/data/peripherals/V208_BLE_LLE.yaml
@@ -1,0 +1,13 @@
+# CH32V208 BLE Link-Layer Engine (gptrLLEReg) — TIMING / STATE / TIMER / DMA.
+#
+# RCC clocks: AHBPCENR bits 6/16/17 — see V208_BLE_BB.yaml note.
+# IRQ: LLE at PFIC vector 64 (defined in interrupts/CH32V2_D8.yaml).
+- name: BLE_LLE
+  address: 0x40024200
+  registers:
+    kind: blelle
+    version: v208
+    block: BLE_LLE
+  interrupts:
+    - signal: GLOBAL
+      interrupt: LLE

--- a/data/peripherals/V208_BLE_RFEND.yaml
+++ b/data/peripherals/V208_BLE_RFEND.yaml
@@ -1,0 +1,10 @@
+# CH32V208 BLE RF Frontend (gptrRFENDReg) — RF analog (PLL/VCO/filter/bias) + calibration.
+#
+# RCC clocks: AHBPCENR bits 6/16/17 — see V208_BLE_BB.yaml note.
+# Canonical base address: 0x40025000.
+- name: BLE_RFEND
+  address: 0x40025000
+  registers:
+    kind: blerfend
+    version: v208
+    block: BLE_RFEND

--- a/data/registers/bleaes_v208.yaml
+++ b/data/registers/bleaes_v208.yaml
@@ -1,0 +1,24 @@
+# CH32V208 BLE AES Engine (gptrAESReg) — only +0x04 cleanup decoded.
+#
+# Scope: only the cleanup-bit pair touched by the BB IRQ path on the ADV TX
+# example is decoded. Full register map TBD; only matters once AES-CCM lands
+# for connection mode.
+block/BLE_AES:
+  description: BLE AES engine — only +0x04 cleanup-bit pair decoded for ADV TX path.
+  items:
+    - name: STATR
+      description: AES op status (bit0 + bit1; cleared sequentially from the BB IRQ path).
+      byte_offset: 4
+      fieldset: STATR
+
+fieldset/STATR:
+  description: BLE_AES status — phase 1 / phase 2 cleanup bits.
+  fields:
+    - name: PHASE2
+      description: AES op cleanup phase 2 (cleared after PHASE1).
+      bit_offset: 0
+      bit_size: 1
+    - name: PHASE1
+      description: AES op cleanup phase 1 (cleared first if set).
+      bit_offset: 1
+      bit_size: 1

--- a/data/registers/blebb_v208.yaml
+++ b/data/registers/blebb_v208.yaml
@@ -1,0 +1,86 @@
+# CH32V208 BLE Baseband (gptrBBReg) — link-layer CTRL/GO/MODE/CFG + IRQ STATUS.
+#
+# Scope: only the items exercised by the working ch32-hal BLE examples
+# (advertising TX + scan RX) are decoded; remaining offsets are left as raw u32
+# placeholders so the block layout stays addressable.
+#
+# Register naming caveat: WCH calls this block "gptrBBReg" but its role is
+# link-layer CTRL/GO/IRQ. The companion block at 0x40024200 ("gptrLLEReg")
+# carries timing/state/DMA. We follow the WCH header naming here.
+block/BLE_BB:
+  description: BLE Baseband — link-layer CTRL/GO/MODE/CFG, IRQ STATUS.
+  items:
+    - name: CTRL
+      description: Baseband control + GO strobes (bit23/bit28 enables, bits[8:7] analog gate).
+      byte_offset: 0
+      fieldset: CTRL
+    - name: MODE
+      description: Baseband mode register (default 0x00090083).
+      byte_offset: 32
+    - name: CFG
+      description: Baseband CFG (bits[30:25] PHY mode = rf_flag, base 0x80010EC8).
+      byte_offset: 44
+      fieldset: CFG
+    - name: TIMING
+      description: Baseband timing (default 0x000001D0 = 464).
+      byte_offset: 52
+    - name: STATR
+      description: IRQ status register (W1C). Read=live status; write 1 to clear.
+      byte_offset: 56
+      fieldset: STATR
+
+fieldset/CTRL:
+  description: BLE_BB CTRL — baseband enable + analog gate.
+  fields:
+    - name: ANALOG_GATE
+      description: Analog gate (BLE_RegInit pre-init clears bit13 sets bit12).
+      bit_offset: 12
+      bit_size: 1
+    - name: ANALOG_CLEAR
+      description: Analog clear bits[8:7] cleared pre-init, bit7 set post-init.
+      bit_offset: 7
+      bit_size: 2
+    - name: BB_EN
+      description: Baseband enable (permanent, set in bb_dev_init).
+      bit_offset: 23
+      bit_size: 1
+    - name: HW_EN
+      description: Hardware enable (permanent, set in bb_dev_init).
+      bit_offset: 28
+      bit_size: 1
+
+fieldset/CFG:
+  description: BLE_BB CFG — PHY mode + base configuration.
+  fields:
+    - name: BASE
+      description: Base config bits[24:0] (default 0x010EC8).
+      bit_offset: 0
+      bit_size: 25
+    - name: RF_FLAG
+      description: PHY mode flag (BB_RF_FLAG_1M = 0x09; bit0=1M PHY enable).
+      bit_offset: 25
+      bit_size: 6
+    - name: HW_RESERVED
+      description: Hardware reserved bit (always set, base=0x80010EC8).
+      bit_offset: 31
+      bit_size: 1
+
+fieldset/STATR:
+  description: BLE_BB IRQ status (W1C — write 1 to clear).
+  fields:
+    - name: BIT4
+      description: IRQ status bit4 — `.L4` cleanup; sets gBleIPPara[4]=1 (re-arm).
+      bit_offset: 4
+      bit_size: 1
+    - name: BIT5
+      description: IRQ status bit5 — paired with bit6 in W1C mask 0x60 (PLL-related).
+      bit_offset: 5
+      bit_size: 1
+    - name: PLL_READY
+      description: PLL-ready (triggers `.L6` TX advance path; W1C with bit5 via 0x60).
+      bit_offset: 6
+      bit_size: 1
+    - name: BIT7
+      description: IRQ status bit7 — `.L8` cleanup; sets gBleIPPara[4]=1 (re-arm).
+      bit_offset: 7
+      bit_size: 1

--- a/data/registers/blelle_v208.yaml
+++ b/data/registers/blelle_v208.yaml
@@ -1,0 +1,97 @@
+# CH32V208 BLE Link-Layer Engine (gptrLLEReg) — TIMING / STATE / TIMER / DMA.
+#
+# Scope: only items touched by the working ch32-hal BLE adv-TX + scan-RX paths
+# are decoded; the rest are filler u32 placeholders so the block layout stays
+# addressable.
+#
+# Naming caveat: WCH header calls this block "gptrLLEReg" but the BB IRQ path
+# also writes CTRL/GO and IRQ at base 0x40024200. Treat the label as
+# informational; physical address is canonical.
+block/BLE_LLE:
+  description: BLE Link-Layer Engine — timing, state machine, IRQ, DMA buffer ptr.
+  items:
+    - name: CTRL
+      description: Link-layer CTRL — channel field bits[5:0], whitening bit6, mode bits[8:7], rate bits[13:12], BLE GO bit23.
+      byte_offset: 0
+      fieldset: CTRL
+    - name: CRC_INIT
+      description: CRC seed (BLE adv default 0x555555).
+      byte_offset: 4
+    - name: ACCESS_ADDR
+      description: Access address / IRQ status (W1C). Read=live status; write 1 to clear, or write ADV AA 0x8E89BED6 for advertising.
+      byte_offset: 8
+    - name: IRQ_MASK
+      description: IRQ mask (default 0xF00F = bits[15:12] + bits[3:0]).
+      byte_offset: 12
+    - name: TIMING0
+      description: Timing slot 0 (default 140).
+      byte_offset: 20
+    - name: STATE_MACHINE
+      description: Link-layer state machine (108=Sleep, 93=ConnRxWait, 97=ConnTxPrep, 101=ConnAckWait, 105=ConnEventClosing, 107=SleepPrep).
+      byte_offset: 28
+      fieldset: STATE_MACHINE
+    - name: TIMING2
+      description: Timing slot 2 (default 140).
+      byte_offset: 36
+    - name: TIMING3
+      description: Timing slot 3 (default 60).
+      byte_offset: 44
+    - name: TIMING4
+      description: Timing slot 4 (default 140).
+      byte_offset: 52
+    - name: TIMING5
+      description: Timing slot 5 (default 60).
+      byte_offset: 60
+    - name: TIMING6
+      description: Timing slot 6 (default 140).
+      byte_offset: 68
+    - name: TIMING7
+      description: Timing slot 7 (default 108).
+      byte_offset: 76
+    - name: SETTLE
+      description: Settle timer used during BLE_RegInit (93 during cal, 0 post).
+      byte_offset: 80
+    - name: TIMER
+      description: Countdown timer for RFEND_WaitTune; written from gBleIPPara[16..19] (=776 for ADV TX).
+      byte_offset: 100
+    - name: SCAN_OFFSET
+      description: Active-scan offset (= gBleIPPara[20..23] << 1, set in `.L6` bit5 path).
+      byte_offset: 108
+    - name: TX_BUF_PTR
+      description: TX buffer base (BB+0x70 in adv.rs; written before ADV GO).
+      byte_offset: 112
+    - name: DMA_BUF
+      description: DMA buffer base address (= gBleIPPara[36] MEMAddr; required non-zero for LLE state machine to fire).
+      byte_offset: 116
+
+fieldset/CTRL:
+  description: BLE_LLE CTRL — channel, whitening, mode, rate, GO.
+  fields:
+    - name: CHANNEL
+      description: BLE logical channel bits[5:0] (37/38/39 for ADV, 0..36 for data).
+      bit_offset: 0
+      bit_size: 6
+    - name: WHITEN
+      description: Whitening enable bit6 (DTM uses 0; ADV may use 1).
+      bit_offset: 6
+      bit_size: 1
+    - name: MODE
+      description: TX/RX mode select bits[8:7] (TX path sets bit8; RX sets bit8+other).
+      bit_offset: 7
+      bit_size: 2
+    - name: RATE
+      description: PHY rate select bits[13:12] (00=1Mbps; non-zero=2M/Coded).
+      bit_offset: 12
+      bit_size: 2
+    - name: BLE_GO
+      description: BLE GO strobe bit23 (lui 0x800; set to fire TX/RX).
+      bit_offset: 23
+      bit_size: 1
+
+fieldset/STATE_MACHINE:
+  description: BLE_LLE state machine value.
+  fields:
+    - name: STATE
+      description: 8-bit state (108=Sleep default; see register description).
+      bit_offset: 0
+      bit_size: 8

--- a/data/registers/blerfend_v208.yaml
+++ b/data/registers/blerfend_v208.yaml
@@ -1,0 +1,172 @@
+# CH32V208 BLE RF Frontend (gptrRFENDReg) — RF analog (PLL/VCO/filter/bias) + calibration.
+#
+# Scope: only items exercised by the working ch32-hal BLE adv-TX + scan-RX
+# paths are decoded; remaining offsets are filler u32 placeholders so the
+# block layout stays addressable.
+#
+# Canonical base address: 0x40025000.
+block/BLE_RFEND:
+  description: BLE RF Frontend — analog config (PLL/VCO/filter/bias) + calibration tables.
+  items:
+    - name: CAL_TRIG
+      description: Calibration trigger/path bits (TX_tune_trigger bit0, TX_cal_mode bit4, TXF_enable bit8, RX_filter_mode bit12, RX_ADC_config bit16).
+      byte_offset: 4
+      fieldset: CAL_TRIG
+    - name: PATH_EN
+      description: TX/RX path enable (RX_ADC bit16, TX cal bit17, TX/RX PLL pre-enable bits[20:21]).
+      byte_offset: 8
+      fieldset: PATH_EN
+    - name: CTRL
+      description: RFEND control + reset (reset sequence writes 0x1101 → 0 → 0x1101; RX_filter_strobe bit4, ADC_ref_strobe bit8).
+      byte_offset: 12
+    - name: CFG0
+      description: RFEND CFG0 (default 0x480, hw-confirmed).
+      byte_offset: 40
+    - name: PLL_VCO
+      description: PLL/VCO config (post_cal_enable bit4, channel-lock release bit1).
+      byte_offset: 44
+    - name: LOOP_FILTER
+      description: PLL loop filter config (bits[3:0]/[7:4]/[10:8]/[22:20]/[30:28]).
+      byte_offset: 48
+    - name: CFG4
+      description: PLL enable (bits[25:19] cleared, bit20 set, bit31 set).
+      byte_offset: 56
+    - name: CFG5_FREQ
+      description: CFG5 + frequency code (bits[15:12]=8, bits[26:24], bits[31:30]; freq_code at bits[15:8] BF00=2401MHz, D300=2440MHz, E700=2480MHz; nCO2440 bits[5:0], nGA2440 bits[30:24]).
+      byte_offset: 60
+      fieldset: CFG5_FREQ
+    - name: PLL_DIV
+      description: PLL integer/frac divider (int_div bits[24:20], frac_div bits[13:0]).
+      byte_offset: 68
+      fieldset: PLL_DIV
+    - name: RF0
+      description: Analog RF0 config (RF analog enable bit31, bits[3:0]=9, bits[26:24]=0b100, bit29).
+      byte_offset: 72
+    - name: RF1
+      description: Analog RF1 bias (bits[2:0]=3, bits[6:4]=3, bits[10:8]=3, bit24=0, bit25=1).
+      byte_offset: 76
+    - name: RF2
+      description: Analog RF2 (bit14 = 1).
+      byte_offset: 80
+    - name: RF2B
+      description: Analog RF2b (bits[3:0]=12, bit7=1, bit12=0).
+      byte_offset: 84
+    - name: ADC_REF
+      description: RX ADC reference enable (bit16).
+      byte_offset: 88
+    - name: TUNE_RESULT
+      description: PLL tune result (CO bits[5:0], tune_done bit25, tune_active bit26). Reading also latches GA into CO_RESULT2.
+      byte_offset: 144
+      fieldset: TUNE_RESULT
+    - name: GA_RESULT
+      description: GA result (bits[16:10], latched by TUNE_RESULT read).
+      byte_offset: 148
+    - name: RX_FILTER_RESULT
+      description: RX filter calibration result (bits[4:0]) + done bit8.
+      byte_offset: 156
+    - name: CO_TABLE1
+      description: CO calibration table 1 — nibble-packed `delta_low * (39-ch)/39` for ch0..ch39 (5×u32).
+      array:
+        len: 5
+        stride: 4
+      byte_offset: 160
+    - name: CO_TABLE2
+      description: CO calibration table 2 — nibble-packed `delta_high * (ch+1)/40` for ch0..ch39 (5×u32).
+      array:
+        len: 5
+        stride: 4
+      byte_offset: 180
+    - name: GA_TABLE
+      description: GA calibration table + CO2 overflow guard (3×u32 covering nibbles for ch40..41 + GA1[0..9] + GA2[0..9]).
+      array:
+        len: 3
+        stride: 4
+      byte_offset: 200
+
+fieldset/CAL_TRIG:
+  description: RFEND calibration trigger/path bits.
+  fields:
+    - name: TX_TUNE_TRIGGER
+      description: TX tune trigger pulse for PLL measurement.
+      bit_offset: 0
+      bit_size: 1
+    - name: TX_CAL_MODE
+      description: TX calibration mode (set during cal, cleared post).
+      bit_offset: 4
+      bit_size: 1
+    - name: TXF_ENABLE
+      description: TX filter enable (set in RFEND_TXFtune; cleared post-cal Bug #3).
+      bit_offset: 8
+      bit_size: 1
+    - name: RX_FILTER_MODE
+      description: RX filter calibration mode (cleared post Bug #3).
+      bit_offset: 12
+      bit_size: 1
+    - name: RX_ADC_CONFIG
+      description: RX ADC config (cleared then set in RFEND_RXAdc).
+      bit_offset: 16
+      bit_size: 1
+
+fieldset/PATH_EN:
+  description: RFEND TX/RX path enable mask (pre-init = 0x00330000 enables bits 16/17/20/21).
+  fields:
+    - name: RX_ADC_PATH
+      description: RX ADC path enable.
+      bit_offset: 16
+      bit_size: 1
+    - name: TX_CAL_PATH
+      description: TX calibration path enable.
+      bit_offset: 17
+      bit_size: 1
+    - name: TX_PLL_PRE
+      description: TX PLL pre-enable.
+      bit_offset: 20
+      bit_size: 1
+    - name: RX_FILTER_PATH
+      description: RX filter path enable.
+      bit_offset: 21
+      bit_size: 1
+
+fieldset/CFG5_FREQ:
+  description: CFG5 + frequency-code register.
+  fields:
+    - name: NCO2440
+      description: Stored CO anchor for default-channel comp (bits[5:0]).
+      bit_offset: 0
+      bit_size: 6
+    - name: FREQ_CODE
+      description: Frequency code bits[15:8] (BF=2401MHz, D3=2440MHz, E7=2480MHz).
+      bit_offset: 8
+      bit_size: 8
+    - name: NGA2440
+      description: Stored GA anchor for default-channel comp (bits[30:24]).
+      bit_offset: 24
+      bit_size: 7
+
+fieldset/PLL_DIV:
+  description: PLL channel divider (programmed by listener.set_channel_freq).
+  fields:
+    - name: FRAC_DIV
+      description: Fractional divider (`((freq_khz % 64000) << 10) / 250` masked to 14 bits).
+      bit_offset: 0
+      bit_size: 14
+    - name: INT_DIV
+      description: Integer divider (`freq_khz / 64000` masked to 5 bits).
+      bit_offset: 20
+      bit_size: 5
+
+fieldset/TUNE_RESULT:
+  description: PLL tune result (CO, tune_done, tune_active).
+  fields:
+    - name: CO
+      description: CO calibration result (read after PLL lock).
+      bit_offset: 0
+      bit_size: 6
+    - name: TUNE_DONE
+      description: Tune done flag — second-check by RFEND_WaitTune.
+      bit_offset: 25
+      bit_size: 1
+    - name: TUNE_ACTIVE
+      description: Tune active flag — set first; double-check semantic.
+      bit_offset: 26
+      bit_size: 1


### PR DESCRIPTION
## Summary

CH32V208 exposes a BLE 5.3 controller as four MMIO blocks. ch32-data had no metadata for any of them, so downstream HALs had to hand-roll volatile MMIO. This PR adds the four register / peripheral files and includes them on `CH32V208WBU6`.

- **`data/registers/blebb_v208.yaml`** — link-layer CTRL/GO, MODE/CFG, IRQ STATR (`gptrBBReg` @ `0x4002_4100`)
- **`data/registers/blelle_v208.yaml`** — TIMING/STATE machine, CHANNEL/MODE/RATE CTRL, ACCESS_ADDR/CRC_INIT, IRQ_MASK, TX_BUF_PTR/DMA_BUF, scheduler timers (`gptrLLEReg` @ `0x4002_4200`)
- **`data/registers/blerfend_v208.yaml`** — PLL/VCO/loop-filter/bias config, NCO programming, calibration tables, TUNE/GA/RX_FILTER results (`gptrRFENDReg` @ `0x4002_5000`)
- **`data/registers/bleaes_v208.yaml`** — only the +0x04 cleanup-bit pair exercised by the BB IRQ path (`gptrAESReg` @ `0x4002_4300`); full map TBD
- **`data/peripherals/V208_BLE_{BB,LLE,RFEND,AES}.yaml`** — peripheral wrappers; BB and LLE wired to PFIC vectors 63 / 64
- **`data/chips/CH32V208WBU6.yaml`** — include the four new peripherals in the V208WBU6 core

Naming follows the stm32-data convention used by chiptool's `:ir_for:` substitution: kinds are single tokens (no underscores), versions may contain underscores. So peripheral kinds are `blebb`, `blelle`, `bleaes`, `blerfend` (with version `v208`); user-facing peripheral const names remain the conventional `BLE_BB` / `BLE_LLE` / `BLE_AES` / `BLE_RFEND` and the generated module structs are `BleBb`, `BleLle`, `BleAes`, `BleRfend`.

## Scope and limitations

Only bit/offset semantics actually exercised by the working ch32-hal BLE adv-TX + scan-RX paths are decoded. Remaining offsets are filler `u32` items so the block layout stays addressable; future revisions can fill them in as connection mode and AES-CCM are added.

**RCC handling** — `rcc_v3.yaml` AHBPCENR currently encodes bit 16 as `ETHMACRXEN` (V307 mapping). On CH32V208 bits 16 / 17 are `BLEC` / `BLES`. To avoid breaking V307 inside the shared rcc_v3, no `rcc:` section is added to the BLE peripheral files; users continue setting AHBPCENR bits 6 / 16 / 17 manually (HAL helper). Splitting rcc per family is left for a follow-up.

## Test plan

- [x] `./d gen` regenerates `build/ch32-metapac` with `blebb_v208.rs` / `blelle_v208.rs` / `bleaes_v208.rs` / `blerfend_v208.rs` modules and chip `pac.rs` exposing `BLE_BB` / `BLE_LLE` / `BLE_AES` / `BLE_RFEND` consts at the four bases above
- [x] `cargo build --release --bin ble_tx_adv_ch37` (ch32-hal `examples/ch32v208/`) against the local-patched metapac — clean (no errors)
- [x] `cargo build --release --bin ble_rx_listener` — clean
- [ ] Reviewer sanity-check on register/field naming + RCC follow-up plan
