### PR TITLE
fix(v00x): correct TIM1/TIM2 remap values and add missing remaps

### DIFF
--- a/data/chips/CH32M007G8R6.yaml
+++ b/data/chips/CH32M007G8R6.yaml
@@ -29,6 +29,7 @@ cores:
     peripherals: []
     include_peripherals:
       - "../family/CH32V00X.yaml"
+      - "../peripherals/V007_M007_TIM2.yaml"
       - "../peripherals/V00X_OPA.yaml"
     include_dma_channels:
       DMA1: "../dma/CH32V00X.yaml"

--- a/data/chips/CH32V002x4x6.yaml
+++ b/data/chips/CH32V002x4x6.yaml
@@ -45,6 +45,7 @@ cores:
     peripherals: []
     include_peripherals:
       - "../family/CH32V00X.yaml"
+      - "../peripherals/V002_V006_TIM2.yaml"
     include_dma_channels:
       DMA1: "../dma/CH32V00X.yaml"
     include_interrupts: "../interrupts/CH32V00X.yaml"

--- a/data/chips/CH32V004x6x1.yaml
+++ b/data/chips/CH32V004x6x1.yaml
@@ -33,6 +33,7 @@ cores:
     peripherals: []
     include_peripherals:
       - "../family/CH32V00X.yaml"
+      - "../peripherals/V002_V006_TIM2.yaml"
     include_dma_channels:
       DMA1: "../dma/CH32V00X.yaml"
     include_interrupts: "../interrupts/CH32V00X.yaml"

--- a/data/chips/CH32V005x6x6.yaml
+++ b/data/chips/CH32V005x6x6.yaml
@@ -39,6 +39,7 @@ cores:
     peripherals: []
     include_peripherals:
       - "../family/CH32V00X.yaml"
+      - "../peripherals/V002_V006_TIM2.yaml"
       - "../peripherals/V00X_OPA.yaml"
     include_dma_channels:
       DMA1: "../dma/CH32V00X.yaml"

--- a/data/chips/CH32V006x8x6.yaml
+++ b/data/chips/CH32V006x8x6.yaml
@@ -39,6 +39,7 @@ cores:
     peripherals: []
     include_peripherals:
       - "../family/CH32V00X.yaml"
+      - "../peripherals/V002_V006_TIM2.yaml"
       - "../peripherals/V00X_OPA.yaml"
     include_dma_channels:
       DMA1: "../dma/CH32V00X.yaml"

--- a/data/chips/CH32V007x8x6.yaml
+++ b/data/chips/CH32V007x8x6.yaml
@@ -33,6 +33,7 @@ cores:
     peripherals: []
     include_peripherals:
       - "../family/CH32V00X.yaml"
+      - "../peripherals/V007_M007_TIM2.yaml"
       - "../peripherals/V00X_OPA.yaml"
     include_dma_channels:
       DMA1: "../dma/CH32V00X.yaml"

--- a/data/family/CH32V00X.yaml
+++ b/data/family/CH32V00X.yaml
@@ -176,24 +176,24 @@
     - { pin: "PA2", signal: "CH2N", remap: 0 }
     - { pin: "PD1", signal: "CH3N", remap: 0 }
     # 1
-    - { pin: "PC5", signal: "ETR", remap: 1 }
-    - { pin: "PC6", signal: "CH1", remap: 1 }
-    - { pin: "PC7", signal: "CH2", remap: 1 }
-    - { pin: "PC0", signal: "CH3", remap: 1 }
-    - { pin: "PD3", signal: "CH4", remap: 1 }
-    - { pin: "PC1", signal: "BKIN", remap: 1 }
-    - { pin: "PC3", signal: "CH1N", remap: 1 }
-    - { pin: "PC4", signal: "CH2N", remap: 1 }
+    - { pin: "PD4", signal: "ETR", remap: 1 }
+    - { pin: "PD2", signal: "CH1", remap: 1 }
+    - { pin: "PA1", signal: "CH2", remap: 1 }
+    - { pin: "PC3", signal: "CH3", remap: 1 }
+    - { pin: "PC4", signal: "CH4", remap: 1 }
+    - { pin: "PC2", signal: "BKIN", remap: 1 }
+    - { pin: "PD0", signal: "CH1N", remap: 1 }
+    - { pin: "PA2", signal: "CH2N", remap: 1 }
     - { pin: "PD1", signal: "CH3N", remap: 1 }
     # 2
-    - { pin: "PD4", signal: "ETR", remap: 2 }
-    - { pin: "PD2", signal: "CH1", remap: 2 }
-    - { pin: "PA1", signal: "CH2", remap: 2 }
-    - { pin: "PC3", signal: "CH3", remap: 2 }
-    - { pin: "PC4", signal: "CH4", remap: 2 }
-    - { pin: "PC2", signal: "BKIN", remap: 2 }
-    - { pin: "PD0", signal: "CH1N", remap: 2 }
-    - { pin: "PA2", signal: "CH2N", remap: 2 }
+    - { pin: "PC5", signal: "ETR", remap: 2 }
+    - { pin: "PC6", signal: "CH1", remap: 2 }
+    - { pin: "PC7", signal: "CH2", remap: 2 }
+    - { pin: "PC0", signal: "CH3", remap: 2 }
+    - { pin: "PD3", signal: "CH4", remap: 2 }
+    - { pin: "PC1", signal: "BKIN", remap: 2 }
+    - { pin: "PC3", signal: "CH1N", remap: 2 }
+    - { pin: "PC4", signal: "CH2N", remap: 2 }
     - { pin: "PD1", signal: "CH3N", remap: 2 }
     # 3
     - { pin: "PC2", signal: "ETR", remap: 3 }
@@ -205,54 +205,67 @@
     - { pin: "PC3", signal: "CH1N", remap: 3 }
     - { pin: "PD2", signal: "CH2N", remap: 3 }
     - { pin: "PC6", signal: "CH3N", remap: 3 }
-
-- name: TIM2
-  address: 0x40000000
-  registers:
-    kind: timer
-    version: v3
-    block: GPTM
-  rcc:
-    bus_clock: HCLK
-    kernel_clock: HCLK
-    enable:
-      register: PB1PCENR
-      field: TIM2EN
-    reset:
-      register: PB1PRSTR
-      field: TIM2RST
-  remap:
-    register: PCFR1
-    field: TIM2_RM
-  interrupts:
-    - { signal: "UP", interrupt: "TIM2" }
-    - { signal: "CC", interrupt: "TIM2" }
-    - { signal: "TRG", interrupt: "TIM2" }
-  pins:
-    # 0
-    - { pin: "PD4", signal: "ETR", remap: 0 }
-    - { pin: "PD4", signal: "CH1", remap: 0 }
-    - { pin: "PD3", signal: "CH2", remap: 0 }
-    - { pin: "PC0", signal: "CH3", remap: 0 }
-    - { pin: "PD7", signal: "CH4", remap: 0 }
-    # 1
-    - { pin: "PC5", signal: "ETR", remap: 1 }
-    - { pin: "PC5", signal: "CH1", remap: 1 }
-    - { pin: "PC2", signal: "CH2", remap: 1 }
-    - { pin: "PD2", signal: "CH3", remap: 1 }
-    - { pin: "PC1", signal: "CH4", remap: 1 }
-    # 2
-    - { pin: "PC1", signal: "ETR", remap: 2 }
-    - { pin: "PC1", signal: "CH1", remap: 2 }
-    - { pin: "PD3", signal: "CH2", remap: 2 }
-    - { pin: "PC0", signal: "CH3", remap: 2 }
-    - { pin: "PD7", signal: "CH4", remap: 2 }
-    # 3
-    - { pin: "PC1", signal: "ETR", remap: 3 }
-    - { pin: "PC1", signal: "CH1", remap: 3 }
-    - { pin: "PC7", signal: "CH2", remap: 3 }
-    - { pin: "PD6", signal: "CH3", remap: 3 }
-    - { pin: "PD5", signal: "CH4", remap: 3 }
+    # 4
+    - { pin: "PD4", signal: "ETR", remap: 4 }
+    - { pin: "PA3", signal: "CH1", remap: 4 }
+    - { pin: "PB0", signal: "CH2", remap: 4 }
+    - { pin: "PB1", signal: "CH3", remap: 4 }
+    - { pin: "PD1", signal: "CH4", remap: 4 }
+    - { pin: "PB3", signal: "BKIN", remap: 4 }
+    - { pin: "PA0", signal: "CH1N", remap: 4 }
+    - { pin: "PA2", signal: "CH2N", remap: 4 }
+    - { pin: "PD0", signal: "CH3N", remap: 4 }
+    # 5
+    - { pin: "PD4", signal: "ETR", remap: 5 }
+    - { pin: "PA3", signal: "CH1", remap: 5 }
+    - { pin: "PB0", signal: "CH2", remap: 5 }
+    - { pin: "PC3", signal: "CH3", remap: 5 }
+    - { pin: "PD1", signal: "CH4", remap: 5 }
+    - { pin: "PB3", signal: "BKIN", remap: 5 }
+    - { pin: "PA0", signal: "CH1N", remap: 5 }
+    - { pin: "PA2", signal: "CH2N", remap: 5 }
+    - { pin: "PD0", signal: "CH3N", remap: 5 }
+    # 6
+    - { pin: "PD4", signal: "ETR", remap: 6 }
+    - { pin: "PA3", signal: "CH1", remap: 6 }
+    - { pin: "PB0", signal: "CH2", remap: 6 }
+    - { pin: "PB1", signal: "CH3", remap: 6 }
+    - { pin: "PB2", signal: "CH4", remap: 6 }
+    - { pin: "PA7", signal: "BKIN", remap: 6 }
+    - { pin: "PA0", signal: "CH1N", remap: 6 }
+    - { pin: "PA2", signal: "CH2N", remap: 6 }
+    - { pin: "PD0", signal: "CH3N", remap: 6 }
+    # 7
+    - { pin: "PB4", signal: "ETR", remap: 7 }
+    - { pin: "PC4", signal: "CH1", remap: 7 }
+    - { pin: "PC5", signal: "CH2", remap: 7 }
+    - { pin: "PC6", signal: "CH3", remap: 7 }
+    - { pin: "PC7", signal: "CH4", remap: 7 }
+    - { pin: "PB2", signal: "BKIN", remap: 7 }
+    - { pin: "PC0", signal: "CH1N", remap: 7 }
+    - { pin: "PC1", signal: "CH2N", remap: 7 }
+    - { pin: "PC2", signal: "CH3N", remap: 7 }
+    # 8
+    - { pin: "PB4", signal: "ETR", remap: 8 }
+    - { pin: "PC4", signal: "CH1", remap: 8 }
+    - { pin: "PC5", signal: "CH2", remap: 8 }
+    - { pin: "PC6", signal: "CH3", remap: 8 }
+    - { pin: "PC7", signal: "CH4", remap: 8 }
+    - { pin: "PB2", signal: "BKIN", remap: 8 }
+    - { pin: "PA3", signal: "CH1N", remap: 8 }
+    - { pin: "PB0", signal: "CH2N", remap: 8 }
+    - { pin: "PB1", signal: "CH3N", remap: 8 }
+    # 9
+    - { pin: "PB4", signal: "ETR", remap: 9 }
+    - { pin: "PA0", signal: "CH1", remap: 9 }
+    - { pin: "PA1", signal: "CH2", remap: 9 }
+    - { pin: "PA2", signal: "CH3", remap: 9 }
+    - { pin: "PA3", signal: "CH4", remap: 9 }
+    - { pin: "PB2", signal: "BKIN", remap: 9 }
+    - { pin: "PC0", signal: "CH1N", remap: 9 }
+    - { pin: "PC1", signal: "CH2N", remap: 9 }
+    - { pin: "PC2", signal: "CH3N", remap: 9 }
+    # TIM1_RM=11xx routes CH1 to the internal LSI clock (no GPIO pin).
 
 - name: USART1
   address: 0x40013800

--- a/data/peripherals/V002_V006_TIM2.yaml
+++ b/data/peripherals/V002_V006_TIM2.yaml
@@ -1,0 +1,72 @@
+# TIM2 pin mapping for CH32V002/V004/V005/V006 (Table 7-9-1).
+- name: TIM2
+  address: 0x40000000
+  registers:
+    kind: timer
+    version: v3
+    block: GPTM
+  rcc:
+    bus_clock: HCLK
+    kernel_clock: HCLK
+    enable:
+      register: PB1PCENR
+      field: TIM2EN
+    reset:
+      register: PB1PRSTR
+      field: TIM2RST
+  remap:
+    register: PCFR1
+    field: TIM2_RM
+  interrupts:
+    - { signal: "UP", interrupt: "TIM2" }
+    - { signal: "CC", interrupt: "TIM2" }
+    - { signal: "TRG", interrupt: "TIM2" }
+  pins:
+    # 0
+    - { pin: "PD4", signal: "ETR", remap: 0 }
+    - { pin: "PD4", signal: "CH1", remap: 0 }
+    - { pin: "PD3", signal: "CH2", remap: 0 }
+    - { pin: "PC0", signal: "CH3", remap: 0 }
+    - { pin: "PD7", signal: "CH4", remap: 0 }
+    # 1
+    - { pin: "PC1", signal: "ETR", remap: 1 }
+    - { pin: "PC1", signal: "CH1", remap: 1 }
+    - { pin: "PD3", signal: "CH2", remap: 1 }
+    - { pin: "PC0", signal: "CH3", remap: 1 }
+    - { pin: "PD7", signal: "CH4", remap: 1 }
+    # 2
+    - { pin: "PC5", signal: "ETR", remap: 2 }
+    - { pin: "PC5", signal: "CH1", remap: 2 }
+    - { pin: "PC2", signal: "CH2", remap: 2 }
+    - { pin: "PD2", signal: "CH3", remap: 2 }
+    - { pin: "PC1", signal: "CH4", remap: 2 }
+    # 3
+    - { pin: "PC1", signal: "ETR", remap: 3 }
+    - { pin: "PC1", signal: "CH1", remap: 3 }
+    - { pin: "PC7", signal: "CH2", remap: 3 }
+    - { pin: "PD6", signal: "CH3", remap: 3 }
+    - { pin: "PD5", signal: "CH4", remap: 3 }
+    # 4
+    - { pin: "PC0", signal: "ETR", remap: 4 }
+    - { pin: "PC0", signal: "CH1", remap: 4 }
+    - { pin: "PC1", signal: "CH2", remap: 4 }
+    - { pin: "PC3", signal: "CH3", remap: 4 }
+    - { pin: "PB6", signal: "CH4", remap: 4 }
+    # 5
+    - { pin: "PA0", signal: "ETR", remap: 5 }
+    - { pin: "PA0", signal: "CH1", remap: 5 }
+    - { pin: "PA1", signal: "CH2", remap: 5 }
+    - { pin: "PA2", signal: "CH3", remap: 5 }
+    - { pin: "PA3", signal: "CH4", remap: 5 }
+    # 6
+    - { pin: "PB1", signal: "ETR", remap: 6 }
+    - { pin: "PB1", signal: "CH1", remap: 6 }
+    - { pin: "PA1", signal: "CH2", remap: 6 }
+    - { pin: "PA2", signal: "CH3", remap: 6 }
+    - { pin: "PA3", signal: "CH4", remap: 6 }
+    # 7
+    - { pin: "PD3", signal: "ETR", remap: 7 }
+    - { pin: "PD3", signal: "CH1", remap: 7 }
+    - { pin: "PD4", signal: "CH2", remap: 7 }
+    - { pin: "PA2", signal: "CH3", remap: 7 }
+    - { pin: "PA3", signal: "CH4", remap: 7 }

--- a/data/peripherals/V007_M007_TIM2.yaml
+++ b/data/peripherals/V007_M007_TIM2.yaml
@@ -1,0 +1,73 @@
+# TIM2 pin mapping for CH32V007/CH32M007 (Table 7-9-2).
+# Differs from V002/V004/V005/V006 only at TIM2_RM=010, where CH2 routes to PB3 instead of PC2.
+- name: TIM2
+  address: 0x40000000
+  registers:
+    kind: timer
+    version: v3
+    block: GPTM
+  rcc:
+    bus_clock: HCLK
+    kernel_clock: HCLK
+    enable:
+      register: PB1PCENR
+      field: TIM2EN
+    reset:
+      register: PB1PRSTR
+      field: TIM2RST
+  remap:
+    register: PCFR1
+    field: TIM2_RM
+  interrupts:
+    - { signal: "UP", interrupt: "TIM2" }
+    - { signal: "CC", interrupt: "TIM2" }
+    - { signal: "TRG", interrupt: "TIM2" }
+  pins:
+    # 0
+    - { pin: "PD4", signal: "ETR", remap: 0 }
+    - { pin: "PD4", signal: "CH1", remap: 0 }
+    - { pin: "PD3", signal: "CH2", remap: 0 }
+    - { pin: "PC0", signal: "CH3", remap: 0 }
+    - { pin: "PD7", signal: "CH4", remap: 0 }
+    # 1
+    - { pin: "PC1", signal: "ETR", remap: 1 }
+    - { pin: "PC1", signal: "CH1", remap: 1 }
+    - { pin: "PD3", signal: "CH2", remap: 1 }
+    - { pin: "PC0", signal: "CH3", remap: 1 }
+    - { pin: "PD7", signal: "CH4", remap: 1 }
+    # 2
+    - { pin: "PC5", signal: "ETR", remap: 2 }
+    - { pin: "PC5", signal: "CH1", remap: 2 }
+    - { pin: "PB3", signal: "CH2", remap: 2 }
+    - { pin: "PD2", signal: "CH3", remap: 2 }
+    - { pin: "PC1", signal: "CH4", remap: 2 }
+    # 3
+    - { pin: "PC1", signal: "ETR", remap: 3 }
+    - { pin: "PC1", signal: "CH1", remap: 3 }
+    - { pin: "PC7", signal: "CH2", remap: 3 }
+    - { pin: "PD6", signal: "CH3", remap: 3 }
+    - { pin: "PD5", signal: "CH4", remap: 3 }
+    # 4
+    - { pin: "PC0", signal: "ETR", remap: 4 }
+    - { pin: "PC0", signal: "CH1", remap: 4 }
+    - { pin: "PC1", signal: "CH2", remap: 4 }
+    - { pin: "PC3", signal: "CH3", remap: 4 }
+    - { pin: "PB6", signal: "CH4", remap: 4 }
+    # 5
+    - { pin: "PA0", signal: "ETR", remap: 5 }
+    - { pin: "PA0", signal: "CH1", remap: 5 }
+    - { pin: "PA1", signal: "CH2", remap: 5 }
+    - { pin: "PA2", signal: "CH3", remap: 5 }
+    - { pin: "PA3", signal: "CH4", remap: 5 }
+    # 6
+    - { pin: "PB1", signal: "ETR", remap: 6 }
+    - { pin: "PB1", signal: "CH1", remap: 6 }
+    - { pin: "PA1", signal: "CH2", remap: 6 }
+    - { pin: "PA2", signal: "CH3", remap: 6 }
+    - { pin: "PA3", signal: "CH4", remap: 6 }
+    # 7
+    - { pin: "PD3", signal: "ETR", remap: 7 }
+    - { pin: "PD3", signal: "CH1", remap: 7 }
+    - { pin: "PD4", signal: "CH2", remap: 7 }
+    - { pin: "PA2", signal: "CH3", remap: 7 }
+    - { pin: "PA3", signal: "CH4", remap: 7 }


### PR DESCRIPTION
## Summary

Rewrites the v00x TIM1/TIM2 pin remap tables to match CH32V00X RM Tables 7-8 and 7-9.

### Fixes
- TIM1 `remap` values 1/2 were swapped vs. the `TIM1_RM` register field, and only the first 4 of 10 remaps were defined.
- TIM2 had the same issue: 4 of 8 remaps defined, with mis-numbered values.

### Adds
- Full TIM1 pin map for remaps 0000–1001 (TIM1_RM=11xx routes CH1 to LSI — not a pin remap).
- Full TIM2 pin map for remaps 000–111, split into two peripheral files since CH2 at TIM2_RM=010 differs between variants:
  - `peripherals/V002_V006_TIM2.yaml` — CH2/PC2 (Table 7-9-1)
  - `peripherals/V007_M007_TIM2.yaml` — CH2/PB3 (Table 7-9-2)

Each v00x chip file now includes the appropriate TIM2 variant.