### PR TITLE
fix: include CH32H* family in metapac gen targets

### DIFF
--- a/d
+++ b/d
@@ -50,7 +50,7 @@ case "$CMD" in
     gen)
         rm -rf build/data
         echo "TODO: More chips to be added"
-        cargo run -p ch32-data-gen && cargo run -p ch32-metapac-gen -- "CH32X03*" "CH32V*" "CH32L*" "CH32M*" CH641 CH643
+        cargo run -p ch32-data-gen && cargo run -p ch32-metapac-gen -- "CH32X03*" "CH32V*" "CH32L*" "CH32M*" "CH32H*" CH641 CH643
     ;;
     ci)
         echo TODO "$CMD"


### PR DESCRIPTION
## Summary

- `./d gen` enumerates families explicitly when invoking `ch32-metapac-gen`
- PR #39 added CH32H417/H416/H415 yaml files under `data/chips/` but didn't add `CH32H*` to the gen invocation
- Result: nightly-publish workflow runs against the H4 merge commit (5e8d693) but emits a `ch32-metapac` that has no H4 chips
- One-line fix: pass `"CH32H*"` alongside the other family globs

## Test plan

- [x] `rm -rf build && ./d gen` from this branch produces 10 H4 chip directories under `build/ch32-metapac/src/chips/` (5 SKUs × V3F/V5F cores)
- [ ] Once merged, the next nightly-publish run should ship H4 chips so downstream consumers (e.g. `ch32-hal` H4 work) can drop their local `[patch."https://github.com/ch32-rs/ch32-metapac"]`