### PR TITLE
h4: make sys_1 writable to match other families

### DIFF
--- a/data/memory/CH32H4_DBMODE0.yaml
+++ b/data/memory/CH32H4_DBMODE0.yaml
@@ -28,5 +28,5 @@ memory:
         write_size: 2
     access:
       read: true
-      write: false
+      write: true
       execute: true

--- a/data/memory/CH32H4_DBMODE1.yaml
+++ b/data/memory/CH32H4_DBMODE1.yaml
@@ -28,5 +28,5 @@ memory:
         write_size: 2
     access:
       read: true
-      write: false
+      write: true
       execute: true


### PR DESCRIPTION
H4's `SYS_1` region was marked `write: false` in both `CH32H4_DBMODE0.yaml` and `CH32H4_DBMODE1.yaml`, but every other family (V003, V00X, V1, V2/V3, L1, X0) has `SYS` as fully read/write/execute. Aligning H4 with the rest.