### PR TITLE
fix: include memory layout files in metapac package

### DIFF
--- a/ch32-metapac-gen/res/Cargo.toml
+++ b/ch32-metapac-gen/res/Cargo.toml
@@ -13,7 +13,14 @@ keywords = ["wch", "ch32", "svd2rust", "no_std", "embedded"]
 readme = "README.md"
 
 # `cargo publish` is unable to figure out which .rs files are needed due to the include! magic.
-include = ["**/*.rs", "**/*.x", "Cargo.toml"]
+include = [
+    "**/*.rs",
+    "**/*.x",
+    "src/chips/**/memory_x/**",
+    "Cargo.toml",
+    "README.md",
+    "LICENSE-*",
+]
 
 [package.metadata.docs.rs]
 features = ["ch32v307vct6", "pac", "metadata"]


### PR DESCRIPTION
This fixes the generated `ch32-metapac` package include list for the new runtime memory layout files introduced by Rich Memory Layout (#36).

`cargo publish --dry-run --features ch32v003f4u6` currently fails after copying README/LICENSE because the crate tarball excludes `src/chips/**/memory_x/**`, so `build.rs` cannot read `memory_x/_default` from the packaged crate. README and license files are also referenced by the manifest/publish metadata, so include them explicitly.

@aq1018 FYI, this is the packaging follow-up for the memory layout work. After this lands, we plan to regenerate/push `ch32-metapac` and publish `ch32-metapac 0.1.0` to crates.io.

Verification:

```sh
./d gen
cd build/ch32-metapac
cp ../../README.md .
cp ../../LICENSE* .
cargo publish --dry-run --features ch32v003f4u6
```

The dry run packages 803 files and verifies `ch32-metapac v0.1.0` successfully.