### PR TITLE
Add V3 OPA peripheral support

### DIFF
--- a/data/chips/CH32V203C6T6.yaml
+++ b/data/chips/CH32V203C6T6.yaml
@@ -40,6 +40,7 @@ cores:
       - "../peripherals/FV2x_V3x_USBD.yaml"
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D6.yaml"
     include_dma_channels:

--- a/data/chips/CH32V203C8T6.yaml
+++ b/data/chips/CH32V203C8T6.yaml
@@ -44,6 +44,7 @@ cores:
       - "../peripherals/FV2x_V3x_USBD.yaml"
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D6.yaml"
     include_dma_channels:

--- a/data/chips/CH32V203C8U6.yaml
+++ b/data/chips/CH32V203C8U6.yaml
@@ -44,6 +44,7 @@ cores:
       - "../peripherals/FV2x_V3x_USBD.yaml"
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D6.yaml"
     include_dma_channels:

--- a/data/chips/CH32V203F6P6.yaml
+++ b/data/chips/CH32V203F6P6.yaml
@@ -37,6 +37,7 @@ cores:
       - "../peripherals/FV2x_V3x_SPI1.yaml"
       - "../peripherals/FV2x_V3x_USBD.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D6.yaml"
     include_dma_channels:

--- a/data/chips/CH32V203F8P6.yaml
+++ b/data/chips/CH32V203F8P6.yaml
@@ -38,6 +38,7 @@ cores:
       - "../peripherals/FV2x_V3x_SPI1.yaml"
       - "../peripherals/FV2x_V3x_I2C1.yaml"
       - "../peripherals/FV2x_V3x_USBFS.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D6.yaml"
     include_dma_channels:

--- a/data/chips/CH32V203F8U6.yaml
+++ b/data/chips/CH32V203F8U6.yaml
@@ -38,6 +38,7 @@ cores:
       - "../peripherals/FV2x_V3x_SPI1.yaml"
       - "../peripherals/FV2x_V3x_I2C1.yaml"
       - "../peripherals/FV2x_V3x_USBD.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D6.yaml"
     include_dma_channels:

--- a/data/chips/CH32V203G6U6.yaml
+++ b/data/chips/CH32V203G6U6.yaml
@@ -39,6 +39,7 @@ cores:
       - "../peripherals/FV2x_V3x_I2C1.yaml"
       - "../peripherals/FV2x_V3x_USBD.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D6.yaml"
     include_dma_channels:

--- a/data/chips/CH32V203G8R6.yaml
+++ b/data/chips/CH32V203G8R6.yaml
@@ -40,6 +40,7 @@ cores:
       - "../peripherals/FV2x_V3x_USBD.yaml"
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D6.yaml"
     include_dma_channels:

--- a/data/chips/CH32V203K6T6.yaml
+++ b/data/chips/CH32V203K6T6.yaml
@@ -39,6 +39,7 @@ cores:
       - "../peripherals/FV2x_V3x_I2C1.yaml"
       - "../peripherals/FV2x_V3x_USBD.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D6.yaml"
     include_dma_channels:

--- a/data/chips/CH32V203K8T6.yaml
+++ b/data/chips/CH32V203K8T6.yaml
@@ -39,6 +39,7 @@ cores:
       - "../peripherals/FV2x_V3x_I2C1.yaml"
       - "../peripherals/FV2x_V3x_USBD.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D6.yaml"
     include_dma_channels:

--- a/data/chips/CH32V203RBT6.yaml
+++ b/data/chips/CH32V203RBT6.yaml
@@ -47,6 +47,7 @@ cores:
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_ETH10.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D8.yaml"
     include_dma_channels:

--- a/data/chips/CH32V208CBU6.yaml
+++ b/data/chips/CH32V208CBU6.yaml
@@ -47,6 +47,7 @@ cores:
       - "../peripherals/FV2x_V3x_USBD.yaml"
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D8.yaml"
     include_dma_channels:

--- a/data/chips/CH32V208GBU6.yaml
+++ b/data/chips/CH32V208GBU6.yaml
@@ -44,6 +44,7 @@ cores:
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_ETH10.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D8.yaml"
     include_dma_channels:

--- a/data/chips/CH32V208RBT6.yaml
+++ b/data/chips/CH32V208RBT6.yaml
@@ -48,6 +48,7 @@ cores:
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_ETH10.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V2_D8.yaml"
     include_dma_channels:

--- a/data/chips/CH32V208WBU6.yaml
+++ b/data/chips/CH32V208WBU6.yaml
@@ -48,6 +48,7 @@ cores:
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_ETH10.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
       # BLE peripherals — scoped to the bits/offsets exercised by the working
       # ch32-hal BLE examples (advertising TX + scan RX). Remaining offsets are
       # left as u32 placeholders so the block layout stays addressable.

--- a/data/chips/CH32V303CBT6.yaml
+++ b/data/chips/CH32V303CBT6.yaml
@@ -53,6 +53,7 @@ cores:
       - "../peripherals/FV2x_V3x_I2C2.yaml"
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V3.yaml"
     include_dma_channels:

--- a/data/chips/CH32V303RBT6.yaml
+++ b/data/chips/CH32V303RBT6.yaml
@@ -54,6 +54,7 @@ cores:
       - "../peripherals/FV2x_V3x_DAC.yaml"
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V3.yaml"
     include_dma_channels:

--- a/data/chips/CH32V303RCT6.yaml
+++ b/data/chips/CH32V303RCT6.yaml
@@ -65,6 +65,7 @@ cores:
       - "../peripherals/FV2x_V3x_SDIO.yaml"
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V3.yaml"
     include_dma_channels:

--- a/data/chips/CH32V303VCT6.yaml
+++ b/data/chips/CH32V303VCT6.yaml
@@ -66,6 +66,7 @@ cores:
       - "../peripherals/FV2x_V3x_SDIO.yaml"
       - "../peripherals/FV2x_V3x_USBFS.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V3.yaml"
     include_dma_channels:

--- a/data/chips/CH32V305FBP6.yaml
+++ b/data/chips/CH32V305FBP6.yaml
@@ -59,6 +59,7 @@ cores:
       - "../peripherals/FV2x_V3x_USBHS.yaml"
       - "../peripherals/FV2x_V3x_DAC.yaml"
       - "../peripherals/FV2x_V3x_CAN2.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V3.yaml"
     include_dma_channels:

--- a/data/chips/CH32V305GBU6.yaml
+++ b/data/chips/CH32V305GBU6.yaml
@@ -67,6 +67,7 @@ cores:
       - "../peripherals/FV2x_V3x_SDIO.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_V3x_CAN2.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V3.yaml"
     include_dma_channels:

--- a/data/chips/CH32V305RBT6.yaml
+++ b/data/chips/CH32V305RBT6.yaml
@@ -67,6 +67,7 @@ cores:
       - "../peripherals/FV2x_V3x_SDIO.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_V3x_CAN2.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V3.yaml"
     include_dma_channels:

--- a/data/chips/CH32V307RCT6.yaml
+++ b/data/chips/CH32V307RCT6.yaml
@@ -74,6 +74,7 @@ cores:
       - "../peripherals/FV2x_V3x_SDIO.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_V3x_CAN2.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
       - "../peripherals/FV3x_ETH.yaml"
 
     include_interrupts: "../interrupts/CH32V3.yaml"

--- a/data/chips/CH32V307VCT6.yaml
+++ b/data/chips/CH32V307VCT6.yaml
@@ -76,6 +76,7 @@ cores:
       - "../peripherals/FV2x_V3x_SDIO.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_V3x_CAN2.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
       - "../peripherals/FV3x_ETH.yaml"
       - "../peripherals/V3x_DVP.yaml"
 

--- a/data/chips/CH32V307WCU6.yaml
+++ b/data/chips/CH32V307WCU6.yaml
@@ -74,6 +74,7 @@ cores:
       - "../peripherals/FV2x_V3x_SDIO.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_V3x_CAN2.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
       - "../peripherals/FV3x_ETH.yaml"
 
     include_interrupts: "../interrupts/CH32V3.yaml"

--- a/data/chips/CH32V317VCT6.yaml
+++ b/data/chips/CH32V317VCT6.yaml
@@ -74,6 +74,7 @@ cores:
       - "../peripherals/FV2x_V3x_SDIO.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_V3x_CAN2.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V3.yaml"
     include_dma_channels:

--- a/data/chips/CH32V317WCU6.yaml
+++ b/data/chips/CH32V317WCU6.yaml
@@ -74,6 +74,7 @@ cores:
       - "../peripherals/FV2x_V3x_SDIO.yaml"
       - "../peripherals/FV2x_V3x_CAN1.yaml"
       - "../peripherals/FV2x_V3x_CAN2.yaml"
+      - "../peripherals/FV2x_V3x_OPA.yaml"
 
     include_interrupts: "../interrupts/CH32V3.yaml"
     include_dma_channels:

--- a/data/peripherals/FV2x_V3x_OPA.yaml
+++ b/data/peripherals/FV2x_V3x_OPA.yaml
@@ -1,0 +1,52 @@
+# OPA on CH32F20x/CH32V20x/CH32V30x/CH32V31x.
+# 4 independent op-amps (OPA1..OPA4). OPA3/OPA4 are only present on D8/D8C variants
+# (CH32F20x_D8, CH32F20x_D8C, CH32V30x_D8, CH32V30x_D8C, CH32V31x_D8C).
+# CH32V307 (V/W/R-CT6, WCU6) is a D8C variant, so all 4 OPAs are populated on this part.
+# No RCC clock gate: the OPA block is powered from the analog rail and has no APB enable bit.
+# No dedicated interrupt vector on this family.
+- name: OPA
+  address: 0x40023804
+  registers:
+    kind: opa
+    version: v3
+    block: OPA
+  pins:
+    # OPA1 positive inputs (PSEL1)
+    - { pin: "PB15", signal: "OPA1_CH0P" }
+    - { pin: "PB0",  signal: "OPA1_CH1P" }
+    # OPA1 negative inputs (NSEL1)
+    - { pin: "PB11", signal: "OPA1_CH0N" }
+    - { pin: "PA6",  signal: "OPA1_CH1N" }
+    # OPA1 outputs (MODE1)
+    - { pin: "PA3",  signal: "OPA1_OUT0" }
+    - { pin: "PE15", signal: "OPA1_OUT1" }
+
+    # OPA2 positive inputs (PSEL2)
+    - { pin: "PB14", signal: "OPA2_CH0P" }
+    - { pin: "PA7",  signal: "OPA2_CH1P" }
+    # OPA2 negative inputs (NSEL2)
+    - { pin: "PB10", signal: "OPA2_CH0N" }
+    - { pin: "PA5",  signal: "OPA2_CH1N" }
+    # OPA2 outputs (MODE2)
+    - { pin: "PA2",  signal: "OPA2_OUT0" }
+    - { pin: "PE14", signal: "OPA2_OUT1" }
+
+    # OPA3 positive inputs (PSEL3) — D8/D8C only
+    - { pin: "PB13", signal: "OPA3_CH0P" }
+    - { pin: "PC5",  signal: "OPA3_CH1P" }
+    # OPA3 negative inputs (NSEL3) — D8/D8C only
+    - { pin: "PB2",  signal: "OPA3_CH0N" }
+    - { pin: "PC2",  signal: "OPA3_CH1N" }
+    # OPA3 outputs (MODE3) — D8/D8C only
+    - { pin: "PA1",  signal: "OPA3_OUT0" }
+    - { pin: "PE7",  signal: "OPA3_OUT1" }
+
+    # OPA4 positive inputs (PSEL4) — D8/D8C only
+    - { pin: "PB12", signal: "OPA4_CH0P" }
+    - { pin: "PC4",  signal: "OPA4_CH1P" }
+    # OPA4 negative inputs (NSEL4) — D8/D8C only
+    - { pin: "PB1",  signal: "OPA4_CH0N" }
+    - { pin: "PC3",  signal: "OPA4_CH1N" }
+    # OPA4 outputs (MODE4) — D8/D8C only
+    - { pin: "PA0",  signal: "OPA4_OUT0" }
+    - { pin: "PE8",  signal: "OPA4_OUT1" }

--- a/data/registers/opa_v3.yaml
+++ b/data/registers/opa_v3.yaml
@@ -1,0 +1,99 @@
+block/OPA:
+  description: OPA configuration register block. 4 independent operational amplifiers (OPA1..OPA4) on CH32F20x/CH32V20x/CH32V30x/CH32V31x.
+  items:
+  - name: CTLR
+    description: OPA control register.
+    byte_offset: 0
+    fieldset: CTLR
+  - name: CTR2
+    description: OPA control register 2 (Configuration Extended Control Register 2 / EXTEN_CTR2). Per-OPA high-speed mode enable.
+    byte_offset: 4
+    fieldset: CTR2
+
+fieldset/CTLR:
+  description: OPA control register. Each OPA has 4 control bits (EN, MODE, NSEL, PSEL) at a 4-bit stride.
+  fields:
+  - name: EN1
+    description: OPA1 enable. 0=disable, 1=enable.
+    bit_offset: 0
+    bit_size: 1
+  - name: MODE1
+    description: OPA1 output channel selection. 0=OPA1_OUT0, 1=OPA1_OUT1.
+    bit_offset: 1
+    bit_size: 1
+  - name: NSEL1
+    description: OPA1 negative input selection. 0=CHN0, 1=CHN1.
+    bit_offset: 2
+    bit_size: 1
+  - name: PSEL1
+    description: OPA1 positive input selection. 0=CHP0, 1=CHP1.
+    bit_offset: 3
+    bit_size: 1
+  - name: EN2
+    description: OPA2 enable. 0=disable, 1=enable.
+    bit_offset: 4
+    bit_size: 1
+  - name: MODE2
+    description: OPA2 output channel selection. 0=OPA2_OUT0, 1=OPA2_OUT1.
+    bit_offset: 5
+    bit_size: 1
+  - name: NSEL2
+    description: OPA2 negative input selection. 0=CHN0, 1=CHN1.
+    bit_offset: 6
+    bit_size: 1
+  - name: PSEL2
+    description: OPA2 positive input selection. 0=CHP0, 1=CHP1.
+    bit_offset: 7
+    bit_size: 1
+  - name: EN3
+    description: OPA3 enable. Only present on D8/D8C variants. 0=disable, 1=enable.
+    bit_offset: 8
+    bit_size: 1
+  - name: MODE3
+    description: OPA3 output channel selection. Only present on D8/D8C variants. 0=OPA3_OUT0, 1=OPA3_OUT1.
+    bit_offset: 9
+    bit_size: 1
+  - name: NSEL3
+    description: OPA3 negative input selection. Only present on D8/D8C variants. 0=CHN0, 1=CHN1.
+    bit_offset: 10
+    bit_size: 1
+  - name: PSEL3
+    description: OPA3 positive input selection. Only present on D8/D8C variants. 0=CHP0, 1=CHP1.
+    bit_offset: 11
+    bit_size: 1
+  - name: EN4
+    description: OPA4 enable. Only present on D8/D8C variants. 0=disable, 1=enable.
+    bit_offset: 12
+    bit_size: 1
+  - name: MODE4
+    description: OPA4 output channel selection. Only present on D8/D8C variants. 0=OPA4_OUT0, 1=OPA4_OUT1.
+    bit_offset: 13
+    bit_size: 1
+  - name: NSEL4
+    description: OPA4 negative input selection. Only present on D8/D8C variants. 0=CHN0, 1=CHN1.
+    bit_offset: 14
+    bit_size: 1
+  - name: PSEL4
+    description: OPA4 positive input selection. Only present on D8/D8C variants. 0=CHP0, 1=CHP1.
+    bit_offset: 15
+    bit_size: 1
+
+fieldset/CTR2:
+  description: OPA control register 2 (Configuration Extended Control Register 2 / EXTEN_CTR2). Each OPA has a 1-bit high-speed mode enable.
+  fields:
+  - name: HSMD1
+    description: OPA1 high-speed mode enable. 0=disable (low-power mode), 1=enable (high-speed mode, higher bandwidth/slew rate).
+    bit_offset: 0
+    bit_size: 1
+  - name: HSMD2
+    description: OPA2 high-speed mode enable. 0=disable (low-power mode), 1=enable (high-speed mode, higher bandwidth/slew rate).
+    bit_offset: 1
+    bit_size: 1
+  - name: HSMD3
+    description: OPA3 high-speed mode enable. Only present on D8/D8C variants. 0=disable (low-power mode), 1=enable (high-speed mode, higher bandwidth/slew rate).
+    bit_offset: 2
+    bit_size: 1
+  - name: HSMD4
+    description: OPA4 high-speed mode enable. Only present on D8/D8C variants. 0=disable (low-power mode), 1=enable (high-speed mode, higher bandwidth/slew rate).
+    bit_offset: 3
+    bit_size: 1


### PR DESCRIPTION
Add support for the OPA peripheral for the V20x/V3 chip families. 

Validated on CH32V307WCU8.