### PR TITLE
fix(usb): correct endpoint register widths

### DIFF
--- a/data/registers/usb_l1fs.yaml
+++ b/data/registers/usb_l1fs.yaml
@@ -437,7 +437,7 @@ fieldset/UEP_CTRL:
     - name: T_TOG
       description: "prepared data toggle flag of USB endpoint X transmittal (IN): 0=DATA0, 1=DATA1."
       bit_offset: 2
-      bit_size: 2
+      bit_size: 1
     - name: T_AUTO_TOG
       bit_offset: 3
       bit_size: 1

--- a/data/registers/usb_v2fs.yaml
+++ b/data/registers/usb_v2fs.yaml
@@ -73,7 +73,7 @@ block/USBD:
     - name: UEP_DMA
       description: endpoint DMA buffer address.
       byte_offset: 16
-      bit_size: 16
+      bit_size: 32
       array:
         len: 8
         stride: 4


### PR DESCRIPTION
codex found it
citations:
- CH32L103: CH32L103RM.PDF, PDF page 299, printed page 297, §20.2.2.12. RB_UEP_T_TOG occupies bit 2, while RB_UEP_T_AUTO_TOG separately occupies bit 3.
- CH32V20x/V30x: CH32FV2x_V3xRM.PDF, PDF page 410, printed page 405, §23.2.2.6. It defines R32_UEPn_DMA as bits [31:0].
