### PR TITLE
fix(v1): add USBFS interrupt metadata

### DIFF
--- a/data/family/CH32V1.yaml
+++ b/data/family/CH32V1.yaml
@@ -386,6 +386,11 @@
     reset:
       register: AHBRSTR
       field: USBHDRST
+  interrupts:
+    - signal: GLOBAL
+      interrupt: USBHD
+    - signal: WKUP
+      interrupt: USB_WKUP
   pins:
     - pin: PA11
       signal: DM


### PR DESCRIPTION
from codex review
citation:
CH32xRM.PDF, PDF pages 62–63, printed pages 60–61, Table 9-2. The CH32V103 vector table lists USBWakeUp at vector 58 and the USB FS transfer interrupt at vector 59.
